### PR TITLE
Tweak homepage styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,16 +117,16 @@
         completely bulletproof!
       </p>
 
-      <div id="sandbox">
+      <div id="sandbox" class="clearfix">
         <div id="inputWrapper">
-          <h2>Input:
+          <h2 class="clearfix">Input:
             <span class="hint">
               <a href="javascript:reportBug()">report</a> a bug
             </span>
           </h2>
         </div>
         <div id="outputWrapper">
-          <h2>Output:
+          <h2 class="clearfix">Output:
             <span class="hint">
               control-return to <a href="javascript:evaluateOutput()">run</a>
             </span>

--- a/sandbox.css
+++ b/sandbox.css
@@ -7,7 +7,7 @@ body {
 
 #content {
   position: relative;
-  margin: 0 250px;
+  margin: 0 250px 40px;
   min-width: 600px;
   max-width: 1024px;
 }
@@ -20,21 +20,23 @@ h1, h2 {
   height: auto;
 }
 
+#sandbox {
+}
+
 #inputWrapper, #outputWrapper {
-  width: 45%;
-  min-width: 300px;
-  position: absolute;
-  height: auto;
+  width: 50%;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 
 #inputWrapper {
-  top: 0;
-  left: 0;
+  float: left;
+  padding-right: 20px;
 }
 
 #outputWrapper {
-  top: 0;
-  right: 0;
+  float: right;
+  padding-left: 20px;
 }
 
 .CodeMirror-scroll {
@@ -51,10 +53,6 @@ h1, h2 {
   display: none;
 }
 
-#sandbox {
-  position: relative;
-}
-
 #attribution, #copyright {
   position: fixed;
   bottom: 25px;
@@ -68,4 +66,10 @@ h1, h2 {
 
 #copyright {
   right: 25px;
+}
+
+.clearfix:after {
+  clear: both;
+  content: "";
+  display: table;
 }


### PR DESCRIPTION
- add clearfix to h2 elements so .hint is properly contained; otherwise the code area becomes too narrow
- switch to floats for two-column layout making it possible to add things below the code (I just added a 40px margin)
- instead of a min-width at which the two columns would have no padding, I switched it to have constant 40px padding in between the columns and to divide the remaining space equally

---

Before:
![](https://f.cloud.github.com/assets/6820/1386353/9246758a-3b70-11e3-998b-d69e4ea8d8de.png)

---

After:
![](https://f.cloud.github.com/assets/6820/1386356/9a4be97c-3b70-11e3-9265-072f78c06ac0.png)
