### PR TITLE
use temp variables in expressions to support multiple yields

### DIFF
--- a/lib/emit.js
+++ b/lib/emit.js
@@ -949,6 +949,7 @@ Ep.explodeExpression = function(path, ignoreResult) {
 
   case "YieldExpression":
     var after = loc();
+    var result = self.makeTempVar();
     var arg = expr.argument && self.explodeExpression(path.get("argument"));
     if (arg && expr.delegate) {
       self.emit(b.returnStatement(b.callExpression(
@@ -959,7 +960,8 @@ Ep.explodeExpression = function(path, ignoreResult) {
       self.emit(b.returnStatement(arg || null));
     }
     self.mark(after);
-    return self.contextProperty("sent");
+    self.emitAssign(result, self.contextProperty("sent"));
+    return result;
 
   default:
     throw new Error(

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -50,6 +50,14 @@ describe("simple argument yielder", function() {
     check(gen("oyez"), ["oyez"]);
     check(gen("foo", "bar"), ["foo"]);
   });
+
+  it("should support multiple yields in expression", function() {
+    function *gen() { return (yield 0) + (yield 0); }
+    var itr = gen();
+    itr.next();
+    itr.next(1);
+    assert.equal(itr.next(2).value, 3);
+  });
 });
 
 describe("range generator", function() {


### PR DESCRIPTION
Example:

``` js
function *x() { return (yield 0) + (yield 0); }
var y = x();
y.next();
y.next(1);
var out = y.next(2);
console.log(out.value); // expected output 3, actual output 4.
```

the return values from `next(x)`s are all stored in $ctx.sent, so only one return value can be used in an expression. Storing the variable immediately after the switch case in a temp-variable should get around this. 
