### PR TITLE
Make sure the binary works even if it’s not installed globally

### DIFF
--- a/bin/regenerator
+++ b/bin/regenerator
@@ -9,4 +9,4 @@ require("assert").strictEqual(
 );
 
 var source = require("fs").readFileSync(file, "utf-8");
-process.stdout.write(require("regenerator")(source));
+process.stdout.write(require("../main")(source));


### PR DESCRIPTION
Closes #30 and #33.
