### PR TITLE
Add og meta tags so FB shares use the "yield" logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
     <link rel="stylesheet" href="codemirror/lib/codemirror.css" />
     <link rel="stylesheet" href="sandbox.css" />
     <link rel="icon" type="image/png" href="yield_ahead.16px.png" />
+    <meta property="og:title" content="Regenerator" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="http://facebook.github.io/regenerator/yield_ahead.200px.png" />
+    <meta property="og:url" content="http://facebook.github.io/regenerator/" />
     <script src="codemirror/mode/javascript.js"></script>
     <script src="runtime/dev.js"></script>
     <script src="bundle.js"></script>


### PR DESCRIPTION
Without this they show the "Fork me on GitHub" banner image.
