### PR TITLE
Optional dependencies are not for running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "recast": "~0.4.23",
     "private": "~0.0.5"
   },
-  "optionalDependencies": {
+  "devDependencies": {
     "mocha": "~1.13.0",
     "semver": "~2.1.0"
   },


### PR DESCRIPTION
As discussed, optionalDependencies is for when the installation of a dependency may fail on certain operating systems or in certain network conditions, and the module is capable of working around this.  e.g. when you have a native C++ version of something, but also a JavaScript fallback to use in development.

Optional dependencies still get installed by anyone depending on your module even though they are not needed.  `devDependencies` on the other hand, are only installed by people trying to run you tests (e.g. travis-ci)
