### PR TITLE
Add a node option to include the runtime

### DIFF
--- a/bin/regenerator
+++ b/bin/regenerator
@@ -6,6 +6,8 @@ var options = require("commander")
   .usage("[options] <file>")
   .option("-r, --include-runtime",
     "Prepend the runtime to the output. [false]", false);
+  .option("-n, --node-runtime",
+    "Prepend the runtine trough a node require call. [false]", false);
   .parse(process.argv);
 
 var file = options.args[0];

--- a/main.js
+++ b/main.js
@@ -22,9 +22,13 @@ assert.ok(
 );
 
 function regenerator(source, options) {
-  var runtime = options.includeRuntime ? fs.readFileSync(
-    regenerator.runtime.dev, "utf-8"
-  ) + "\n" : "";
+  var runtime = "";
+  if (options.includeRuntime) {
+    runtime = fs.readFileSync(regenerator.runtime.dev, "utf-8") + "\n";
+  } else if (options.nodeRuntime) {
+    runtime = "var wrapGenerator = " +
+        "require(\"regenerator/runtime/dev\").wrapGenerator;\n";
+  }
 
   if (!genFunExp.test(source)) {
     return runtime + source; // Shortcut: no generators to transform.


### PR DESCRIPTION
I think this option can be useful when using this library in node so that you don't have to include the entire runtime with the `-r` option in each file or have to require `wrapGenerator` yourself.
