### PR TITLE
Broken tests for `yield* fn()` where the return value is wrong

### DIFF
--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -944,4 +944,30 @@ describe("yield* generator", function () {
 
     assert.equal(value, 4)
   })
+
+  it("returns correc thing", function () {
+    function pumpNumber(gen) {
+      var n = 0
+
+      while (true) {
+        var res = gen.next(n)
+        n = res.value
+        if (res.done) return n
+      }
+    }
+
+    function* foo() {
+      return (yield* bar()) + (yield* bar())
+    }
+
+    function* bar() {
+      return (yield 2) + (yield 3)
+    }
+
+    var res1 = pumpNumber(bar())
+    var res2 = pumpNumber(foo())
+
+    assert.equal(res1, 5)
+    assert.equal(res2, 10)
+  })
 })


### PR DESCRIPTION
This is a broken test for bug #52 aswell as a similar bug.

I'm not sure what is wrong but for some reason the result of `yield* bar()` is either undefined or the last thing that was yielded from `bar` instead of the return value.
