### PR TITLE
Fix #70

### DIFF
--- a/lib/visit.js
+++ b/lib/visit.js
@@ -19,6 +19,14 @@ exports.transform = function(ast) {
   return types.traverse(ast, visitNode);
 };
 
+// Makes a unique context identifier. This is needed to handle retrieval of
+// tempvars from contexts up the scope in nested generator situation.
+// see issue #70
+var nextCtxId = 0;
+function makeContextId() {
+  return b.identifier("$ctx" + nextCtxId++);
+}
+
 function visitNode(node) {
   if (!n.Function.check(node) || !node.generator) {
     // Note that because we are not returning false here the traversal
@@ -37,7 +45,7 @@ function visitNode(node) {
   }
 
   // TODO Ensure these identifiers are named uniquely.
-  var contextId = b.identifier("$ctx");
+  var contextId = makeContextId();
   var functionId = node.id ? b.identifier(node.id.name + "$") : null/*Anonymous*/;
   var argsId = b.identifier("$args");
   var wrapGeneratorId = b.identifier("wrapGenerator");

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -168,6 +168,28 @@ describe("try-catch generator", function() {
   });
 });
 
+describe("nested generators in try-catch", function() {
+  function *gen() {
+    try {
+       nonExistent;
+    } catch (e) {
+      yield function* () {
+        yield e;
+      }
+    }
+  }
+
+  it('should get a reference to the caught error', function () {
+    var gen2 = gen().next().value();
+    var res = gen2.next();
+    assert.ok(res.value instanceof ReferenceError);
+    // Note that we don't do strict equality over the message because it varies
+    // across browsers (if we ever want to run tests in browsers).
+    assert.ok(res.value.message.match(/nonExistent/));
+  });
+
+});
+
 describe("try-finally generator", function() {
   function *usingThrow(condition) {
     yield 0;


### PR DESCRIPTION
When we have nested generators and we want to get a reference to caught error
up the scope, we need to have a reference to the context `$ctx` variable of that generator.
This makes `$ctx` unique across each generated generator code. Fixes #70.
