### PR TITLE
Insert wrapGenerator.mark call after "use strict"

### DIFF
--- a/lib/visit.js
+++ b/lib/visit.js
@@ -100,6 +100,15 @@ function visitNode(node) {
 
     if (path) {
       var firstStmtPath = path.get("body", 0);
+
+      // If the first statement is a "use strict" declaration, make sure to
+      // insert our call afterwards
+      if (n.ExpressionStatement.check(firstStmtPath.value) &&
+          n.Literal.check(firstStmtPath.value.expression) &&
+          firstStmtPath.value.expression.value === "use strict") {
+        firstStmtPath = path.get("body", 1);
+      }
+
       firstStmtPath.replace(
         b.expressionStatement(b.callExpression(markMethod, [node.id])),
         firstStmtPath.value


### PR DESCRIPTION
Fixes #88.

Test Plan: Run

```
node -e "console.log(require('./main.js')('\\'use strict\\';function *range() {}'))"
```

and observe that the mark() call is after the "use strict" line.
