### PR TITLE
Implement the `@@iterator` method on generators.

### DIFF
--- a/runtime/dev.js
+++ b/runtime/dev.js
@@ -183,6 +183,9 @@
     generator.next = invoke.bind(generator, "next");
     generator.throw = invoke.bind(generator, "throw");
 
+    var iteratorSymbol = typeof Symbol === "function" && Symbol.iterator || "@@iterator";
+    generator[iteratorSymbol] = function() { return generator; };
+
     return generator;
   }
 

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -55,6 +55,33 @@ describe("wrapGenerator", function() {
   });
 });
 
+(runningInTranslation ? describe : xdescribe)("@@iterator", function() {
+  var Symbol;
+
+  before(function() {
+    Symbol = global.Symbol;
+    global.Symbol = function(){};
+    global.Symbol.iterator = '@@iterator';
+  });
+
+  after(function() {
+    global.Symbol = Symbol;
+  });
+
+  it("is defined on generator iterators to return themselves", function() {
+    function *gen(){}
+    var iterator = gen();
+    assert.strictEqual(iterator['@@iterator'](), iterator);
+  });
+
+  it("uses whatever Symbol.iterator is as the property", function() {
+    global.Symbol.iterator = 'ITERITER';
+    function *gen(){}
+    var iterator = gen();
+    assert.strictEqual(iterator.ITERITER(), iterator);
+  });
+});
+
 describe("simple argument yielder", function() {
   it("should yield only its first argument", function() {
     function *gen(x) {


### PR DESCRIPTION
Per the [spec](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator.prototype-@@iterator), all this method does is return the generator itself. This is necessary to make generators from regenerator work properly with the spread element, which uses the `@@iterator` property on objects.
