### PR TITLE
Delay invalid completion record assertion message

### DIFF
--- a/lib/emit.js
+++ b/lib/emit.js
@@ -778,11 +778,12 @@ Ep.explodeStatement = function(path, labelId) {
 };
 
 Ep.emitAbruptCompletion = function(record) {
-  assert.ok(
-    isValidCompletion(record),
-    "invalid completion record: " +
-      JSON.stringify(record)
-  );
+  try {
+    assert.ok(isValidCompletion(record));
+  } catch (err) {
+    err.message = "invalid completion record: " + JSON.stringify(record);
+    throw err;
+  }
 
   assert.notStrictEqual(
     record.type, "normal",


### PR DESCRIPTION
This delays the generation of the invalid completion record assertion message. It's an unnecessary performance hit to have to `JSON.stringify` all passed nodes and it'll throw up if you have a recursive property (which in my use-case there is).
