### PR TITLE
:arrow_up: defs@~1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "promise": "~6.0.0",
     "private": "~0.1.5",
     "through": "~2.3.6",
-    "defs": "~1.0.1"
+    "defs": "~1.1.0"
   },
   "devDependencies": {
     "mocha": "~1.21.4",


### PR DESCRIPTION
uses `esprima-fb` now
