### PR TITLE
Use the value for remote.path directly in fs.readFileSync

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,7 +52,7 @@ function compile(source, options) {
     return {
       // Shortcut: no generators or async functions to transform.
       code: (options.includeRuntime === true ? fs.readFileSync(
-        runtime.path, "utf-8"
+        path.join(__dirname, "runtime.js"), "utf-8"
       ) + "\n" : "") + source
     };
   }


### PR DESCRIPTION
There is a bug in brfs which disallows passing variables to fs.readFileSync.
This means that anyone using this module with Browserify will have a breaking
build. This can be fixed by using the value of remote.path directly, which,
while not optimal, solves the issue while the bug for fs.readFileSync is fixed.

I'm not sure if this PR is the right way to go about it, or to wait until brfs
addresses the issue. This PR is what I am using to fix my current build.

See more here: https://github.com/substack/brfs/issues/36