### PR TITLE
Fix JS hoisting issue by using different var name

### DIFF
--- a/main.js
+++ b/main.js
@@ -59,8 +59,8 @@ function compile(source, options) {
 
   var recastOptions = getRecastOptions(options);
   var ast = recast.parse(source, recastOptions);
-  var path = new types.NodePath(ast);
-  var programPath = path.get("program");
+  var nodePath = new types.NodePath(ast);
+  var programPath = nodePath.get("program");
 
   if (shouldVarify(source, options)) {
     // Transpile let/const into var declarations.
@@ -69,7 +69,7 @@ function compile(source, options) {
 
   transform(programPath, options);
 
-  return recast.print(path, recastOptions);
+  return recast.print(nodePath, recastOptions);
 }
 
 function normalizeOptions(options) {


### PR DESCRIPTION
This is the fix for bug introduced by https://github.com/facebook/regenerator/pull/177. Code reads file in sync way and it assumes `path` variable is pointing to `path` module, but as there is another `path` declaration within the same scope (`var path = new types.NodePath(ast);`), it gets hoisted on top and so `path` becomes `undefined`. It leads to following JS error:

```
TypeError: Cannot call method 'join' of undefined
```