### PR TITLE
Do not reset temp vars on Context init

### DIFF
--- a/runtime.js
+++ b/runtime.js
@@ -376,7 +376,7 @@
     // locations where there is no enclosing try statement.
     this.tryEntries = [{ tryLoc: "root" }];
     tryLocsList.forEach(pushTryEntry, this);
-    this.reset();
+    this.reset(true);
   }
 
   runtime.keys = function(object) {
@@ -449,7 +449,7 @@
   Context.prototype = {
     constructor: Context,
 
-    reset: function() {
+    reset: function(skipTempReset) {
       this.prev = 0;
       this.next = 0;
       this.sent = undefined;
@@ -460,10 +460,12 @@
 
       // Pre-initialize at least 20 temporary variables to enable hidden
       // class optimizations for simple generators.
-      for (var tempIndex = 0, tempName;
-           hasOwn.call(this, tempName = "t" + tempIndex) || tempIndex < 20;
-           ++tempIndex) {
-        this[tempName] = null;
+      if (!skipTempReset) {
+        for (var tempIndex = 0, tempName;
+             hasOwn.call(this, tempName = "t" + tempIndex) || tempIndex < 20;
+             ++tempIndex) {
+          this[tempName] = null;
+        }
       }
     },
 

--- a/runtime.js
+++ b/runtime.js
@@ -458,13 +458,14 @@
 
       this.tryEntries.forEach(resetTryEntry);
 
-      // Pre-initialize at least 20 temporary variables to enable hidden
-      // class optimizations for simple generators.
       if (!skipTempReset) {
-        for (var tempIndex = 0, tempName;
-             hasOwn.call(this, tempName = "t" + tempIndex) || tempIndex < 20;
-             ++tempIndex) {
-          this[tempName] = null;
+        for (var name in this) {
+          // Not sure about the optimal order of these conditions:
+          if (name.charAt(0) === "t" &&
+              hasOwn.call(this, name) &&
+              !isNaN(+name.slice(1))) {
+            this[name] = undefined;
+          }
         }
       }
     },


### PR DESCRIPTION
We know that they will not exist at this point so the overhead of iterating and running the has own property check is unnecessary.

This led to 4-16x speed increases for the Babel generator tests defined here:
http://kpdecker.github.io/six-speed/