### PR TITLE
Reset rather than delete sent field on next

### DIFF
--- a/runtime.js
+++ b/runtime.js
@@ -280,7 +280,7 @@
           if (state === GenStateSuspendedYield) {
             context.sent = arg;
           } else {
-            delete context.sent;
+            context.sent = undefined;
           }
 
         } else if (method === "throw") {


### PR DESCRIPTION
Delete was causing deoptimization due to backing class change and was unnecessary as this field was explicitly initialized to undefined and was not being checked for existence as best I can tell.

When combined with #207 saw a 40x throughput improvement under FF, from 39k operations/sec to 1.6M ops/src on http://kpdecker.github.io/six-speed/