### PR TITLE
Wrap global delete in try/catch for ie8

### DIFF
--- a/runtime-module.js
+++ b/runtime-module.js
@@ -23,5 +23,9 @@ if (hadRuntime) {
   g.regeneratorRuntime = oldRuntime;
 } else {
   // Remove the global property added by runtime.js.
-  delete g.regeneratorRuntime;
+  try {
+    delete g.regeneratorRuntime;
+  } catch(e) {
+    g.regeneratorRuntime = undefined;
+  }
 }


### PR DESCRIPTION
For ie8, deleting window properties only works you delete them as a variable from the global scope:
i.e.
```
window.foo = 1; 
delete foo; // works

window.bar = 1;
delete window.bar //errors
```
