### PR TITLE
Support TypeCastExpression

### DIFF
--- a/lib/emit.js
+++ b/lib/emit.js
@@ -1205,6 +1205,9 @@ Ep.explodeExpression = function(path, ignoreResult) {
 
     return self.contextProperty("sent");
 
+  case "TypeCastExpression":
+    return self.explodeExpression(path.get('expression'));
+
   default:
     throw new Error(
       "unknown Expression of type " +


### PR DESCRIPTION
Add a simple case statement to support parsing code with type cast expressions in them.

Should resolve: https://github.com/babel/babel/issues/2477

Just so that there's a record here, regenerator threw an error when trying to parse code with a type cast expression in it, like so: 

```javascript
function *test() {
  ((yield 4): number);
}
```