### PR TITLE
Convert to a Babel plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ var es5SourceWithRuntime = require("regenerator").compile(es6Source, {
 }).code;
 ```
 
-AST transformation:
+Babel plugin:
 ```js
-var recast = require("recast");
-var ast = recast.parse(es6Source);
-ast = require("regenerator").transform(ast);
-var es5Source = recast.print(ast);
+var babel = require("babel-core");
+var code = babel.transform(es6Source, {
+  plugins: [require("generator")]
+}).code;
 ```
 
 How can you get involved?

--- a/bin/regenerator
+++ b/bin/regenerator
@@ -10,12 +10,8 @@ require("commoner").version(
 }).option(
   "-r, --include-runtime",
   "Prepend the runtime to the output."
-).option(
-  "--disable-async",
-  "Disable transformation of async functions."
 ).process(function(id, source) {
   return compile(source, {
-    includeRuntime: this.options.includeRuntime,
-    disableAsync: this.options.disableAsync
+    includeRuntime: this.options.includeRuntime
   }).code;
 });

--- a/lib/emit.js
+++ b/lib/emit.js
@@ -8,11 +8,9 @@
  * the same directory.
  */
 
+var traverse = require("babel-traverse");
 var assert = require("assert");
-var types = require("recast").types;
-var isArray = types.builtInTypes.array;
-var b = types.builders;
-var n = types.namedTypes;
+var t = require("babel-types");
 var leap = require("./leap");
 var meta = require("./meta");
 var util = require("./util");
@@ -21,7 +19,7 @@ var hasOwn = Object.prototype.hasOwnProperty;
 
 function Emitter(contextId) {
   assert.ok(this instanceof Emitter);
-  n.Identifier.assert(contextId);
+  t.assertIdentifier(contextId);
 
   // Used to generate unique temporary names.
   this.nextTempId = 0;
@@ -69,13 +67,13 @@ exports.Emitter = Emitter;
 // location to be determined at any time, even after generating code that
 // refers to the location.
 function loc() {
-  return b.literal(-1);
+  return t.numberLiteral(-1);
 }
 
 // Sets the exact value of the given location to the offset of the next
 // Statement emitted.
 Ep.mark = function(loc) {
-  n.Literal.assert(loc);
+  t.assertLiteral(loc);
   var index = this.listing.length;
   if (loc.value === -1) {
     loc.value = index;
@@ -89,9 +87,9 @@ Ep.mark = function(loc) {
 };
 
 Ep.emit = function(node) {
-  if (n.Expression.check(node))
-    node = b.expressionStatement(node);
-  n.Statement.assert(node);
+  if (t.isExpression(node))
+    node = t.expressionStatement(node);
+  t.assertStatement(node);
   this.listing.push(node);
 };
 
@@ -104,16 +102,16 @@ Ep.emitAssign = function(lhs, rhs) {
 
 // Shorthand for an assignment statement.
 Ep.assign = function(lhs, rhs) {
-  return b.expressionStatement(
-    b.assignmentExpression("=", lhs, rhs));
+  return t.expressionStatement(
+    t.assignmentExpression("=", lhs, rhs));
 };
 
 // Convenience function for generating expressions like context.next,
 // context.sent, and context.rval.
 Ep.contextProperty = function(name, computed) {
-  return b.memberExpression(
+  return t.memberExpression(
     this.contextId,
-    computed ? b.literal(name) : b.identifier(name),
+    computed ? t.stringLiteral(name) : t.identifier(name),
     !!computed
   );
 };
@@ -128,7 +126,7 @@ Ep.stop = function(rval) {
 };
 
 Ep.setReturnValue = function(valuePath) {
-  n.Expression.assert(valuePath.value);
+  t.assertExpression(valuePath.value);
 
   this.emitAssign(
     this.contextProperty("rval"),
@@ -137,9 +135,9 @@ Ep.setReturnValue = function(valuePath) {
 };
 
 Ep.clearPendingException = function(tryLoc, assignee) {
-  n.Literal.assert(tryLoc);
+  t.assertLiteral(tryLoc);
 
-  var catchCall = b.callExpression(
+  var catchCall = t.callExpression(
     this.contextProperty("catch", true),
     [tryLoc]
   );
@@ -155,42 +153,42 @@ Ep.clearPendingException = function(tryLoc, assignee) {
 // exact value of the location is not yet known.
 Ep.jump = function(toLoc) {
   this.emitAssign(this.contextProperty("next"), toLoc);
-  this.emit(b.breakStatement());
+  this.emit(t.breakStatement());
 };
 
 // Conditional jump.
 Ep.jumpIf = function(test, toLoc) {
-  n.Expression.assert(test);
-  n.Literal.assert(toLoc);
+  t.assertExpression(test);
+  t.assertLiteral(toLoc);
 
-  this.emit(b.ifStatement(
+  this.emit(t.ifStatement(
     test,
-    b.blockStatement([
+    t.blockStatement([
       this.assign(this.contextProperty("next"), toLoc),
-      b.breakStatement()
+      t.breakStatement()
     ])
   ));
 };
 
 // Conditional jump, with the condition negated.
 Ep.jumpIfNot = function(test, toLoc) {
-  n.Expression.assert(test);
-  n.Literal.assert(toLoc);
+  t.assertExpression(test);
+  t.assertLiteral(toLoc);
 
   var negatedTest;
-  if (n.UnaryExpression.check(test) &&
+  if (t.isUnaryExpression(test) &&
       test.operator === "!") {
     // Avoid double negation.
     negatedTest = test.argument;
   } else {
-    negatedTest = b.unaryExpression("!", test);
+    negatedTest = t.unaryExpression("!", test);
   }
 
-  this.emit(b.ifStatement(
+  this.emit(t.ifStatement(
     negatedTest,
-    b.blockStatement([
+    t.blockStatement([
       this.assign(this.contextProperty("next"), toLoc),
-      b.breakStatement()
+      t.breakStatement()
     ])
   ));
 };
@@ -205,10 +203,10 @@ Ep.makeTempVar = function() {
 };
 
 Ep.getContextFunction = function(id) {
-  return b.functionExpression(
+  return t.functionExpression(
     id || null/*Anonymous*/,
     [this.contextId],
-    b.blockStatement([this.getDispatchLoop()]),
+    t.blockStatement([this.getDispatchLoop()]),
     false, // Not a generator anymore!
     false // Nor an expression.
   );
@@ -236,15 +234,15 @@ Ep.getDispatchLoop = function() {
 
   self.listing.forEach(function(stmt, i) {
     if (self.marked.hasOwnProperty(i)) {
-      cases.push(b.switchCase(
-        b.literal(i),
+      cases.push(t.switchCase(
+        t.numberLiteral(i),
         current = []));
       alreadyEnded = false;
     }
 
     if (!alreadyEnded) {
       current.push(stmt);
-      if (isSwitchCaseEnder(stmt))
+      if (t.isCompletionStatement(stmt))
         alreadyEnded = true;
     }
   });
@@ -254,24 +252,24 @@ Ep.getDispatchLoop = function() {
   this.finalLoc.value = this.listing.length;
 
   cases.push(
-    b.switchCase(this.finalLoc, [
+    t.switchCase(this.finalLoc, [
       // Intentionally fall through to the "end" case...
     ]),
 
     // So that the runtime can jump to the final location without having
     // to know its offset, we provide the "end" case as a synonym.
-    b.switchCase(b.literal("end"), [
+    t.switchCase(t.stringLiteral("end"), [
       // This will check/clear both context.thrown and context.rval.
-      b.returnStatement(
-        b.callExpression(this.contextProperty("stop"), [])
+      t.returnStatement(
+        t.callExpression(this.contextProperty("stop"), [])
       )
     ])
   );
 
-  return b.whileStatement(
-    b.literal(1),
-    b.switchStatement(
-      b.assignmentExpression(
+  return t.whileStatement(
+    t.numberLiteral(1),
+    t.switchStatement(
+      t.assignmentExpression(
         "=",
         this.contextProperty("prev"),
         this.contextProperty("next")
@@ -280,14 +278,6 @@ Ep.getDispatchLoop = function() {
     )
   );
 };
-
-// See comment above re: alreadyEnded.
-function isSwitchCaseEnder(stmt) {
-  return n.BreakStatement.check(stmt)
-      || n.ContinueStatement.check(stmt)
-      || n.ReturnStatement.check(stmt)
-      || n.ThrowStatement.check(stmt);
-}
 
 Ep.getTryLocsList = function() {
   if (this.tryEntries.length === 0) {
@@ -298,7 +288,7 @@ Ep.getTryLocsList = function() {
 
   var lastLocValue = 0;
 
-  return b.arrayExpression(
+  return t.arrayExpression(
     this.tryEntries.map(function(tryEntry) {
       var thisLocValue = tryEntry.firstLoc.value;
       assert.ok(thisLocValue >= lastLocValue, "try entries out of order");
@@ -318,7 +308,7 @@ Ep.getTryLocsList = function() {
         locs[3] = fe.afterLoc;
       }
 
-      return b.arrayExpression(locs);
+      return t.arrayExpression(locs);
     })
   );
 };
@@ -331,21 +321,21 @@ Ep.getTryLocsList = function() {
 // No destructive modification of AST nodes.
 
 Ep.explode = function(path, ignoreResult) {
-  assert.ok(path instanceof types.NodePath);
+  assert.ok(path instanceof traverse.NodePath);
 
-  var node = path.value;
+  var node = path.node;
   var self = this;
 
-  n.Node.assert(node);
+  t.assertNode(node);
 
-  if (n.Statement.check(node))
+  if (t.isDeclaration(node))
+    throw getDeclError(node);
+
+  if (t.isStatement(node))
     return self.explodeStatement(path);
 
-  if (n.Expression.check(node))
+  if (t.isExpression(node))
     return self.explodeExpression(path, ignoreResult);
-
-  if (n.Declaration.check(node))
-    throw getDeclError(node);
 
   switch (node.type) {
   case "Program":
@@ -380,26 +370,26 @@ function getDeclError(node) {
 }
 
 Ep.explodeStatement = function(path, labelId) {
-  assert.ok(path instanceof types.NodePath);
+  assert.ok(path instanceof traverse.NodePath);
 
-  var stmt = path.value;
+  var stmt = path.node;
   var self = this;
 
-  n.Statement.assert(stmt);
+  t.assertStatement(stmt);
 
   if (labelId) {
-    n.Identifier.assert(labelId);
+    t.assertIdentifier(labelId);
   } else {
     labelId = null;
   }
 
   // Explode BlockStatement nodes even if they do not contain a yield,
   // because we don't want or need the curly braces.
-  if (n.BlockStatement.check(stmt)) {
-    return path.get("body").each(
-      self.explodeStatement,
-      self
-    );
+  if (t.isBlockStatement(stmt)) {
+    path.get("body").forEach(function (path) {
+      self.explodeStatement(path);
+    });
+    return;
   }
 
   if (!meta.containsLeap(stmt)) {
@@ -520,6 +510,9 @@ Ep.explodeStatement = function(path, labelId) {
 
     break;
 
+  case "TypeCastExpression":
+    return self.explodeExpression(path.get("expression"));
+
   case "ForInStatement":
     var head = loc();
     var after = loc();
@@ -527,7 +520,7 @@ Ep.explodeStatement = function(path, labelId) {
     var keyIterNextFn = self.makeTempVar();
     self.emitAssign(
       keyIterNextFn,
-      b.callExpression(
+      t.callExpression(
         runtimeProperty("keys"),
         [self.explodeExpression(path.get("right"))]
       )
@@ -537,13 +530,13 @@ Ep.explodeStatement = function(path, labelId) {
 
     var keyInfoTmpVar = self.makeTempVar();
     self.jumpIf(
-      b.memberExpression(
-        b.assignmentExpression(
+      t.memberExpression(
+        t.assignmentExpression(
           "=",
           keyInfoTmpVar,
-          b.callExpression(keyIterNextFn, [])
+          t.callExpression(keyIterNextFn, [])
         ),
-        b.identifier("done"),
+        t.identifier("done"),
         false
       ),
       after
@@ -551,9 +544,9 @@ Ep.explodeStatement = function(path, labelId) {
 
     self.emitAssign(
       stmt.left,
-      b.memberExpression(
+      t.memberExpression(
         keyInfoTmpVar,
-        b.identifier("value"),
+        t.identifier("value"),
         false
       )
     );
@@ -603,11 +596,11 @@ Ep.explodeStatement = function(path, labelId) {
 
     for (var i = cases.length - 1; i >= 0; --i) {
       var c = cases[i];
-      n.SwitchCase.assert(c);
+      t.assertSwitchCase(c);
 
       if (c.test) {
-        condition = b.conditionalExpression(
-          b.binaryExpression("===", disc, c.test),
+        condition = t.conditionalExpression(
+          t.binaryExpression("===", disc, c.test),
           caseLocs[i] = loc(),
           condition
         );
@@ -616,23 +609,22 @@ Ep.explodeStatement = function(path, labelId) {
       }
     }
 
-    self.jump(self.explodeExpression(
-      new types.NodePath(condition, path, "discriminant")
-    ));
+    var discriminant = path.get("discriminant");
+    discriminant.replaceWith(condition);
+    self.jump(self.explodeExpression(discriminant));
 
     self.leapManager.withEntry(
       new leap.SwitchEntry(after),
       function() {
-        path.get("cases").each(function(casePath) {
-          var c = casePath.value;
-          var i = casePath.name;
+        path.get("cases").forEach(function(casePath) {
+          var c = casePath.node;
+          var i = casePath.key;
 
           self.mark(caseLocs[i]);
 
-          casePath.get("consequent").each(
-            self.explodeStatement,
-            self
-          );
+          casePath.get("consequent").forEach(function (path) {
+            self.explodeStatement(path);
+          });
         });
       }
     );
@@ -682,9 +674,6 @@ Ep.explodeStatement = function(path, labelId) {
     var after = loc();
 
     var handler = stmt.handler;
-    if (!handler && stmt.handlers) {
-      handler = stmt.handlers[0] || null;
-    }
 
     var catchLoc = handler && loc();
     var catchEntry = catchLoc && new leap.CatchEntry(
@@ -723,36 +712,17 @@ Ep.explodeStatement = function(path, labelId) {
 
         self.updateContextPrevLoc(self.mark(catchLoc));
 
-        var bodyPath = path.get("handler", "body");
+        var bodyPath = path.get("handler.body");
         var safeParam = self.makeTempVar();
         self.clearPendingException(tryEntry.firstLoc, safeParam);
 
         var catchScope = bodyPath.scope;
-        var catchParamName = handler.param.name;
-        n.CatchClause.assert(catchScope.node);
-        assert.strictEqual(catchScope.lookup(catchParamName), catchScope);
+        // TODO: t.assertCatchClause(catchScope.block);
+        // TODO: assert.strictEqual(catchScope.lookup(catchParamName), catchScope);
 
-        types.visit(bodyPath, {
-          visitIdentifier: function(path) {
-            if (util.isReference(path, catchParamName) &&
-                path.scope.lookup(catchParamName) === catchScope) {
-              return safeParam;
-            }
-
-            this.traverse(path);
-          },
-
-          visitFunction: function(path) {
-            if (path.scope.declares(catchParamName)) {
-              // Don't descend into nested scopes that shadow the catch
-              // parameter with their own declarations. This isn't
-              // logically necessary because of the path.scope.lookup we
-              // do in visitIdentifier, but it saves time.
-              return false;
-            }
-
-            this.traverse(path);
-          }
+        bodyPath.traverse(catchParamVisitor, {
+          safeParam: safeParam,
+          catchParamName: handler.param.name
         });
 
         self.leapManager.withEntry(catchEntry, function() {
@@ -767,7 +737,7 @@ Ep.explodeStatement = function(path, labelId) {
           self.explodeStatement(path.get("finalizer"));
         });
 
-        self.emit(b.returnStatement(b.callExpression(
+        self.emit(t.returnStatement(t.callExpression(
           self.contextProperty("finish"),
           [finallyEntry.firstLoc]
         )));
@@ -779,7 +749,7 @@ Ep.explodeStatement = function(path, labelId) {
     break;
 
   case "ThrowStatement":
-    self.emit(b.throwStatement(
+    self.emit(t.throwStatement(
       self.explodeExpression(path.get("argument"))
     ));
 
@@ -789,6 +759,22 @@ Ep.explodeStatement = function(path, labelId) {
     throw new Error(
       "unknown Statement of type " +
         JSON.stringify(stmt.type));
+  }
+};
+
+var catchParamVisitor = {
+  Identifier: function(path, state) {
+    if (path.node.name === state.catchParamName && util.isReference(path)) {
+      path.replaceWith(state.safeParam);
+    }
+  },
+
+  Scope: function(path, state) {
+    if (path.scope.hasOwnBinding(state.catchParamName)) {
+      // Don't descend into nested scopes that shadow the catch
+      // parameter with their own declarations.
+      path.skip();
+    }
   }
 };
 
@@ -806,23 +792,23 @@ Ep.emitAbruptCompletion = function(record) {
     "normal completions are not abrupt"
   );
 
-  var abruptArgs = [b.literal(record.type)];
+  var abruptArgs = [t.stringLiteral(record.type)];
 
   if (record.type === "break" ||
       record.type === "continue") {
-    n.Literal.assert(record.target);
+    t.assertLiteral(record.target);
     abruptArgs[1] = record.target;
   } else if (record.type === "return" ||
              record.type === "throw") {
     if (record.value) {
-      n.Expression.assert(record.value);
+      t.assertExpression(record.value);
       abruptArgs[1] = record.value;
     }
   }
 
   this.emit(
-    b.returnStatement(
-      b.callExpression(
+    t.returnStatement(
+      t.callExpression(
         this.contextProperty("abrupt"),
         abruptArgs
       )
@@ -840,7 +826,7 @@ function isValidCompletion(record) {
   if (type === "break" ||
       type === "continue") {
     return !hasOwn.call(record, "value")
-        && n.Literal.check(record.target);
+        && t.isLiteral(record.target);
   }
 
   if (type === "return" ||
@@ -863,7 +849,7 @@ function isValidCompletion(record) {
 // targets, but minimizing the number of switch cases keeps the generated
 // code shorter.
 Ep.getUnmarkedCurrentLoc = function() {
-  return b.literal(this.listing.length);
+  return t.numberLiteral(this.listing.length);
 };
 
 // The context.prev property takes the value of context.next whenever we
@@ -878,7 +864,7 @@ Ep.getUnmarkedCurrentLoc = function() {
 // be costly and verbose to set context.prev before every statement.
 Ep.updateContextPrevLoc = function(loc) {
   if (loc) {
-    n.Literal.assert(loc);
+    t.assertLiteral(loc);
 
     if (loc.value === -1) {
       // If an uninitialized location literal was passed in, set its value
@@ -900,11 +886,11 @@ Ep.updateContextPrevLoc = function(loc) {
 };
 
 Ep.explodeExpression = function(path, ignoreResult) {
-  assert.ok(path instanceof types.NodePath);
+  assert.ok(path instanceof traverse.NodePath);
 
-  var expr = path.value;
+  var expr = path.node;
   if (expr) {
-    n.Expression.assert(expr);
+    t.assertExpression(expr);
   } else {
     return expr;
   }
@@ -913,7 +899,7 @@ Ep.explodeExpression = function(path, ignoreResult) {
   var result; // Used optionally by several cases below.
 
   function finish(expr) {
-    n.Expression.assert(expr);
+    t.assertExpression(expr);
     if (ignoreResult) {
       self.emit(expr);
     } else {
@@ -943,7 +929,7 @@ Ep.explodeExpression = function(path, ignoreResult) {
   // control the precise order in which the generated code realizes the
   // side effects of those subexpressions.
   function explodeViaTempVar(tempVar, childPath, ignoreChildResult) {
-    assert.ok(childPath instanceof types.NodePath);
+    assert.ok(childPath instanceof traverse.NodePath);
 
     assert.ok(
       !ignoreChildResult || !tempVar,
@@ -957,7 +943,7 @@ Ep.explodeExpression = function(path, ignoreResult) {
       // Side effects already emitted above.
 
     } else if (tempVar || (hasLeapingChildren &&
-                           !n.Literal.check(result))) {
+                           !t.isLiteral(result))) {
       // If tempVar was provided, then the result will always be assigned
       // to it, even if the result does not otherwise need to be assigned
       // to a temporary variable.  When no tempVar is provided, we have
@@ -983,7 +969,7 @@ Ep.explodeExpression = function(path, ignoreResult) {
 
   switch (expr.type) {
   case "MemberExpression":
-    return finish(b.memberExpression(
+    return finish(t.memberExpression(
       self.explodeExpression(path.get("object")),
       expr.computed
         ? explodeViaTempVar(null, path.get("property"))
@@ -999,12 +985,12 @@ Ep.explodeExpression = function(path, ignoreResult) {
     var newArgs = [];
 
     var hasLeapingArgs = false;
-    argsPath.each(function(argPath) {
+    argsPath.forEach(function(argPath) {
       hasLeapingArgs = hasLeapingArgs ||
-        meta.containsLeap(argPath.value);
+        meta.containsLeap(argPath.node);
     });
 
-    if (n.MemberExpression.check(calleePath.value)) {
+    if (t.isMemberExpression(calleePath.node)) {
       if (hasLeapingArgs) {
         // If the arguments of the CallExpression contained any yield
         // expressions, then we need to be sure to evaluate the callee
@@ -1019,19 +1005,19 @@ Ep.explodeExpression = function(path, ignoreResult) {
           calleePath.get("object")
         );
 
-        var newProperty = calleePath.value.computed
+        var newProperty = calleePath.node.computed
           ? explodeViaTempVar(null, calleePath.get("property"))
-          : calleePath.value.property;
+          : calleePath.node.property;
 
         newArgs.unshift(newObject);
 
-        newCallee = b.memberExpression(
-          b.memberExpression(
+        newCallee = t.memberExpression(
+          t.memberExpression(
             newObject,
             newProperty,
-            calleePath.value.computed
+            calleePath.node.computed
           ),
-          b.identifier("call"),
+          t.identifier("call"),
           false
         );
 
@@ -1042,7 +1028,7 @@ Ep.explodeExpression = function(path, ignoreResult) {
     } else {
       newCallee = self.explodeExpression(calleePath);
 
-      if (n.MemberExpression.check(newCallee)) {
+      if (t.isMemberExpression(newCallee)) {
         // If the callee was not previously a MemberExpression, then the
         // CallExpression was "unqualified," meaning its `this` object
         // should be the global object. If the exploded expression has
@@ -1051,24 +1037,24 @@ Ep.explodeExpression = function(path, ignoreResult) {
         // by using the (0, object.property)(...) trick; otherwise, it
         // will receive the object of the MemberExpression as its `this`
         // object.
-        newCallee = b.sequenceExpression([
-          b.literal(0),
+        newCallee = t.sequenceExpression([
+          t.numberLiteral(0),
           newCallee
         ]);
       }
     }
 
-    argsPath.each(function(argPath) {
+    argsPath.forEach(function(argPath) {
       newArgs.push(explodeViaTempVar(null, argPath));
     });
 
-    return finish(b.callExpression(
+    return finish(t.callExpression(
       newCallee,
       newArgs
     ));
 
   case "NewExpression":
-    return finish(b.newExpression(
+    return finish(t.newExpression(
       explodeViaTempVar(null, path.get("callee")),
       path.get("arguments").map(function(argPath) {
         return explodeViaTempVar(null, argPath);
@@ -1076,18 +1062,22 @@ Ep.explodeExpression = function(path, ignoreResult) {
     ));
 
   case "ObjectExpression":
-    return finish(b.objectExpression(
+    return finish(t.objectExpression(
       path.get("properties").map(function(propPath) {
-        return b.property(
-          propPath.value.kind,
-          propPath.value.key,
-          explodeViaTempVar(null, propPath.get("value"))
-        );
+        if (propPath.isObjectProperty()) {
+          return t.objectProperty(
+            propPath.node.key,
+            explodeViaTempVar(null, propPath.get("value")),
+            propPath.node.computed
+          );
+        } else {
+          return propPath.node;
+        }
       })
     ));
 
   case "ArrayExpression":
-    return finish(b.arrayExpression(
+    return finish(t.arrayExpression(
       path.get("elements").map(function(elemPath) {
         return explodeViaTempVar(null, elemPath);
       })
@@ -1096,8 +1086,8 @@ Ep.explodeExpression = function(path, ignoreResult) {
   case "SequenceExpression":
     var lastIndex = expr.expressions.length - 1;
 
-    path.get("expressions").each(function(exprPath) {
-      if (exprPath.name === lastIndex) {
+    path.get("expressions").forEach(function(exprPath) {
+      if (exprPath.key === lastIndex) {
         result = self.explodeExpression(exprPath, ignoreResult);
       } else {
         self.explodeExpression(exprPath, true);
@@ -1150,7 +1140,7 @@ Ep.explodeExpression = function(path, ignoreResult) {
     return result;
 
   case "UnaryExpression":
-    return finish(b.unaryExpression(
+    return finish(t.unaryExpression(
       expr.operator,
       // Can't (and don't need to) break up the syntax of the argument.
       // Think about delete a[b].
@@ -1159,21 +1149,21 @@ Ep.explodeExpression = function(path, ignoreResult) {
     ));
 
   case "BinaryExpression":
-    return finish(b.binaryExpression(
+    return finish(t.binaryExpression(
       expr.operator,
       explodeViaTempVar(null, path.get("left")),
       explodeViaTempVar(null, path.get("right"))
     ));
 
   case "AssignmentExpression":
-    return finish(b.assignmentExpression(
+    return finish(t.assignmentExpression(
       expr.operator,
       self.explodeExpression(path.get("left")),
       self.explodeExpression(path.get("right"))
     ));
 
   case "UpdateExpression":
-    return finish(b.updateExpression(
+    return finish(t.updateExpression(
       expr.operator,
       self.explodeExpression(path.get("argument")),
       expr.prefix
@@ -1186,10 +1176,10 @@ Ep.explodeExpression = function(path, ignoreResult) {
     if (arg && expr.delegate) {
       var result = self.makeTempVar();
 
-      self.emit(b.returnStatement(b.callExpression(
+      self.emit(t.returnStatement(t.callExpression(
         self.contextProperty("delegateYield"), [
           arg,
-          b.literal(result.property.name),
+          t.stringLiteral(result.property.name),
           after
         ]
       )));
@@ -1200,7 +1190,7 @@ Ep.explodeExpression = function(path, ignoreResult) {
     }
 
     self.emitAssign(self.contextProperty("next"), after);
-    self.emit(b.returnStatement(arg || null));
+    self.emit(t.returnStatement(arg || null));
     self.mark(after);
 
     return self.contextProperty("sent");

--- a/lib/hoist.js
+++ b/lib/hoist.js
@@ -8,10 +8,9 @@
  * the same directory.
  */
 
+var traverse = require("babel-traverse");
 var assert = require("assert");
-var types = require("recast").types;
-var n = types.namedTypes;
-var b = types.builders;
+var t = require("babel-types");
 var hasOwn = Object.prototype.hasOwnProperty;
 
 // The hoist function takes a FunctionExpression or FunctionDeclaration
@@ -19,20 +18,21 @@ var hasOwn = Object.prototype.hasOwnProperty;
 // returns a VariableDeclaration containing just the names of the removed
 // declarations.
 exports.hoist = function(funPath) {
-  assert.ok(funPath instanceof types.NodePath);
-  n.Function.assert(funPath.value);
+  assert.ok(funPath instanceof traverse.NodePath);
+  t.assertFunction(funPath.node);
 
   var vars = {};
 
   function varDeclToExpr(vdec, includeIdentifiers) {
-    n.VariableDeclaration.assert(vdec);
+    t.assertVariableDeclaration(vdec);
+    // TODO assert.equal(vdec.kind, "var");
     var exprs = [];
 
     vdec.declarations.forEach(function(dec) {
       vars[dec.id.name] = dec.id;
 
       if (dec.init) {
-        exprs.push(b.assignmentExpression(
+        exprs.push(t.assignmentExpression(
           "=", dec.id, dec.init
         ));
       } else if (includeIdentifiers) {
@@ -46,51 +46,51 @@ exports.hoist = function(funPath) {
     if (exprs.length === 1)
       return exprs[0];
 
-    return b.sequenceExpression(exprs);
+    return t.sequenceExpression(exprs);
   }
 
-  types.visit(funPath.get("body"), {
-    visitVariableDeclaration: function(path) {
-      var expr = varDeclToExpr(path.value, false);
-      if (expr === null) {
-        path.replace();
-      } else {
-        // We don't need to traverse this expression any further because
-        // there can't be any new declarations inside an expression.
-        return b.expressionStatement(expr);
-      }
+  funPath.get("body").traverse({
+    VariableDeclaration: {
+      exit: function(path) {
+        var expr = varDeclToExpr(path.node, false);
+        if (expr === null) {
+          path.remove();
+        } else {
+          // We don't need to traverse this expression any further because
+          // there can't be any new declarations inside an expression.
+          path.replaceWith(t.expressionStatement(expr));
+        }
 
-      // Since the original node has been either removed or replaced,
-      // avoid traversing it any further.
-      return false;
+        // Since the original node has been either removed or replaced,
+        // avoid traversing it any further.
+        path.skip();
+      }
     },
 
-    visitForStatement: function(path) {
-      var init = path.value.init;
-      if (n.VariableDeclaration.check(init)) {
-        path.get("init").replace(varDeclToExpr(init, false));
+    ForStatement: function(path) {
+      var init = path.node.init;
+      if (t.isVariableDeclaration(init)) {
+        path.get("init").replaceWith(varDeclToExpr(init, false));
       }
-      this.traverse(path);
     },
 
-    visitForInStatement: function(path) {
-      var left = path.value.left;
-      if (n.VariableDeclaration.check(left)) {
-        path.get("left").replace(varDeclToExpr(left, true));
+    ForXStatement: function(path) {
+      var left = path.get("left");
+      if (left.isVariableDeclaration()) {
+        left.replaceWith(varDeclToExpr(left.node, true));
       }
-      this.traverse(path);
     },
 
-    visitFunctionDeclaration: function(path) {
-      var node = path.value;
+    FunctionDeclaration: function(path) {
+      var node = path.node;
       vars[node.id.name] = node.id;
 
       var parentNode = path.parent.node;
-      var assignment = b.expressionStatement(
-        b.assignmentExpression(
+      var assignment = t.expressionStatement(
+        t.assignmentExpression(
           "=",
           node.id,
-          b.functionExpression(
+          t.functionExpression(
             node.id,
             node.params,
             node.body,
@@ -100,36 +100,35 @@ exports.hoist = function(funPath) {
         )
       );
 
-      if (n.BlockStatement.check(path.parent.node)) {
+      if (path.parentPath.isBlockStatement()) {
         // Insert the assignment form before the first statement in the
         // enclosing block.
-        path.parent.get("body").unshift(assignment);
+        path.parentPath.unshiftContainer("body", assignment);
 
         // Remove the function declaration now that we've inserted the
         // equivalent assignment form at the beginning of the block.
-        path.replace();
-
+        path.remove();
       } else {
         // If the parent node is not a block statement, then we can just
         // replace the declaration with the equivalent assignment form
         // without worrying about hoisting it.
-        path.replace(assignment);
+        path.replaceWith(assignment);
       }
 
       // Don't hoist variables out of inner functions.
-      return false;
+      path.skip();
     },
 
-    visitFunctionExpression: function(path) {
+    FunctionExpression: function(path) {
       // Don't descend into nested function expressions.
-      return false;
+      path.skip();
     }
   });
 
   var paramNames = {};
-  funPath.get("params").each(function(paramPath) {
-    var param = paramPath.value;
-    if (n.Identifier.check(param)) {
+  funPath.get("params").forEach(function(paramPath) {
+    var param = paramPath.node;
+    if (t.isIdentifier(param)) {
       paramNames[param.name] = param;
     } else {
       // Variables declared by destructuring parameter patterns will be
@@ -141,7 +140,7 @@ exports.hoist = function(funPath) {
 
   Object.keys(vars).forEach(function(name) {
     if (!hasOwn.call(paramNames, name)) {
-      declarations.push(b.variableDeclarator(vars[name], null));
+      declarations.push(t.variableDeclarator(vars[name], null));
     }
   });
 
@@ -149,5 +148,5 @@ exports.hoist = function(funPath) {
     return null; // Be sure to handle this case!
   }
 
-  return b.variableDeclaration("var", declarations);
+  return t.variableDeclaration("var", declarations);
 };

--- a/lib/leap.js
+++ b/lib/leap.js
@@ -9,9 +9,7 @@
  */
 
 var assert = require("assert");
-var types = require("recast").types;
-var n = types.namedTypes;
-var b = types.builders;
+var t = require("babel-types");
 var inherits = require("util").inherits;
 var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -21,7 +19,7 @@ function Entry() {
 
 function FunctionEntry(returnLoc) {
   Entry.call(this);
-  n.Literal.assert(returnLoc);
+  t.assertLiteral(returnLoc);
   this.returnLoc = returnLoc;
 }
 
@@ -31,11 +29,11 @@ exports.FunctionEntry = FunctionEntry;
 function LoopEntry(breakLoc, continueLoc, label) {
   Entry.call(this);
 
-  n.Literal.assert(breakLoc);
-  n.Literal.assert(continueLoc);
+  t.assertLiteral(breakLoc);
+  t.assertLiteral(continueLoc);
 
   if (label) {
-    n.Identifier.assert(label);
+    t.assertIdentifier(label);
   } else {
     label = null;
   }
@@ -50,7 +48,7 @@ exports.LoopEntry = LoopEntry;
 
 function SwitchEntry(breakLoc) {
   Entry.call(this);
-  n.Literal.assert(breakLoc);
+  t.assertLiteral(breakLoc);
   this.breakLoc = breakLoc;
 }
 
@@ -60,7 +58,7 @@ exports.SwitchEntry = SwitchEntry;
 function TryEntry(firstLoc, catchEntry, finallyEntry) {
   Entry.call(this);
 
-  n.Literal.assert(firstLoc);
+  t.assertLiteral(firstLoc);
 
   if (catchEntry) {
     assert.ok(catchEntry instanceof CatchEntry);
@@ -88,8 +86,8 @@ exports.TryEntry = TryEntry;
 function CatchEntry(firstLoc, paramId) {
   Entry.call(this);
 
-  n.Literal.assert(firstLoc);
-  n.Identifier.assert(paramId);
+  t.assertLiteral(firstLoc);
+  t.assertIdentifier(paramId);
 
   this.firstLoc = firstLoc;
   this.paramId = paramId;
@@ -100,8 +98,8 @@ exports.CatchEntry = CatchEntry;
 
 function FinallyEntry(firstLoc, afterLoc) {
   Entry.call(this);
-  n.Literal.assert(firstLoc);
-  n.Literal.assert(afterLoc);
+  t.assertLiteral(firstLoc);
+  t.assertLiteral(afterLoc);
   this.firstLoc = firstLoc;
   this.afterLoc = afterLoc;
 }
@@ -112,8 +110,8 @@ exports.FinallyEntry = FinallyEntry;
 function LabeledEntry(breakLoc, label) {
   Entry.call(this);
 
-  n.Literal.assert(breakLoc);
-  n.Identifier.assert(label);
+  t.assertLiteral(breakLoc);
+  t.assertIdentifier(label);
 
   this.breakLoc = breakLoc;
   this.label = label;

--- a/lib/meta.js
+++ b/lib/meta.js
@@ -10,14 +10,12 @@
 
 var assert = require("assert");
 var m = require("private").makeAccessor();
-var types = require("recast").types;
-var isArray = types.builtInTypes.array;
-var n = types.namedTypes;
+var t = require("babel-types");
 var hasOwn = Object.prototype.hasOwnProperty;
 
 function makePredicate(propertyName, knownTypes) {
   function onlyChildren(node) {
-    n.Node.assert(node);
+    t.assertNode(node);
 
     // Assume no side effects until we find out otherwise.
     var result = false;
@@ -25,24 +23,29 @@ function makePredicate(propertyName, knownTypes) {
     function check(child) {
       if (result) {
         // Do nothing.
-      } else if (isArray.check(child)) {
+      } else if (Array.isArray(child)) {
         child.some(check);
-      } else if (n.Node.check(child)) {
+      } else if (t.isNode(child)) {
         assert.strictEqual(result, false);
         result = predicate(child);
       }
       return result;
     }
 
-    types.eachField(node, function(name, child) {
-      check(child);
-    });
+    var keys = t.VISITOR_KEYS[node.type];
+    if (keys) {
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        var child = node[key];
+        check(child);
+      }
+    }
 
     return result;
   }
 
   function predicate(node) {
-    n.Node.assert(node);
+    t.assertNode(node);
 
     var meta = m(node);
     if (hasOwn.call(meta, propertyName))

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,94 +8,16 @@
  * the same directory.
  */
 
-var assert = require("assert");
-var types = require("recast").types;
-var n = types.namedTypes;
-var b = types.builders;
-var hasOwn = Object.prototype.hasOwnProperty;
-
-exports.defaults = function(obj) {
-  var len = arguments.length;
-  var extension;
-
-  for (var i = 1; i < len; ++i) {
-    if ((extension = arguments[i])) {
-      for (var key in extension) {
-        if (hasOwn.call(extension, key) && !hasOwn.call(obj, key)) {
-          obj[key] = extension[key];
-        }
-      }
-    }
-  }
-
-  return obj;
-};
+var t = require("babel-types");
 
 exports.runtimeProperty = function(name) {
-  return b.memberExpression(
-    b.identifier("regeneratorRuntime"),
-    b.identifier(name),
+  return t.memberExpression(
+    t.identifier("regeneratorRuntime"),
+    t.identifier(name),
     false
   );
 };
 
-// Inspired by the isReference function from ast-util:
-// https://github.com/eventualbuddha/ast-util/blob/9bf91c5ce8/lib/index.js#L466-L506
-exports.isReference = function(path, name) {
-  var node = path.value;
-
-  if (!n.Identifier.check(node)) {
-    return false;
-  }
-
-  if (name && node.name !== name) {
-    return false;
-  }
-
-  var parent = path.parent.value;
-
-  switch (parent.type) {
-  case "VariableDeclarator":
-    return path.name === "init";
-
-  case "MemberExpression":
-    return path.name === "object" || (
-      parent.computed && path.name === "property"
-    );
-
-  case "FunctionExpression":
-  case "FunctionDeclaration":
-  case "ArrowFunctionExpression":
-    if (path.name === "id") {
-      return false;
-    }
-
-    if (path.parentPath.name === "params" &&
-        parent.params === path.parentPath.value &&
-        parent.params[path.name] === node) {
-      return false;
-    }
-
-    return true;
-
-  case "ClassDeclaration":
-  case "ClassExpression":
-    return path.name !== "id";
-
-  case "CatchClause":
-    return path.name !== "param";
-
-  case "Property":
-  case "MethodDefinition":
-    return path.name !== "key";
-
-  case "ImportSpecifier":
-  case "ImportDefaultSpecifier":
-  case "ImportNamespaceSpecifier":
-  case "LabeledStatement":
-    return false;
-
-  default:
-    return true;
-  }
+exports.isReference = function(path) {
+  return path.isReferenced() || path.parentPath.isAssignmentExpression({ left: path.node });
 };

--- a/lib/visit.js
+++ b/lib/visit.js
@@ -8,261 +8,149 @@
  * the same directory.
  */
 
+var traverse = require("babel-traverse");
+var babylon = require("babylon");
 var assert = require("assert");
 var fs = require("fs");
-var recast = require("recast");
-var types = recast.types;
-var n = types.namedTypes;
-var b = types.builders;
-var isArray = types.builtInTypes.array;
-var isObject = types.builtInTypes.object;
-var NodePath = types.NodePath;
+var t = require("babel-types");
 var hoist = require("./hoist").hoist;
 var Emitter = require("./emit").Emitter;
 var util = require("./util");
 var runtimeProperty = util.runtimeProperty;
 var getMarkInfo = require("private").makeAccessor();
 
-exports.transform = function transform(node, options) {
-  options = options || {};
+exports.visitor = {
+  Function: {
+    exit: function(path, state) {
+      var node = path.node;
 
-  var path = node instanceof NodePath ? node : new NodePath(node);
-  visitor.visit(path, options);
-  node = path.value;
-
-  if (options.includeRuntime === true ||
-      (options.includeRuntime === 'if used' && visitor.wasChangeReported())) {
-    injectRuntime(n.File.check(node) ? node.program : node);
-  }
-
-  options.madeChanges = visitor.wasChangeReported();
-
-  return node;
-};
-
-function injectRuntime(program) {
-  n.Program.assert(program);
-
-  // Include the runtime by modifying the AST rather than by concatenating
-  // strings. This technique will allow for more accurate source mapping.
-  var runtimePath = require("..").runtime.path;
-  var runtime = fs.readFileSync(runtimePath, "utf8");
-  var runtimeBody = recast.parse(runtime, {
-    sourceFileName: runtimePath
-  }).program.body;
-
-  var body = program.body;
-  body.unshift.apply(body, runtimeBody);
-}
-
-var visitor = types.PathVisitor.fromMethodsObject({
-  reset: function(node, options) {
-    this.options = options;
-  },
-
-  visitFunction: function(path) {
-    // Calling this.traverse(path) first makes for a post-order traversal.
-    this.traverse(path);
-
-    var node = path.value;
-    var shouldTransformAsync = node.async && !this.options.disableAsync;
-
-    if (!node.generator && !shouldTransformAsync) {
-      return;
-    }
-
-    this.reportChanged();
-
-    if (node.expression) {
-      // Transform expression lambdas into normal functions.
-      node.expression = false;
-      node.body = b.blockStatement([
-        b.returnStatement(node.body)
-      ]);
-    }
-
-    if (shouldTransformAsync) {
-      awaitVisitor.visit(path.get("body"));
-    }
-
-    var outerBody = [];
-    var innerBody = [];
-    var bodyPath = path.get("body", "body");
-
-    bodyPath.each(function(childPath) {
-      var node = childPath.value;
-      if (node && node._blockHoist != null) {
-        outerBody.push(node);
+      if (node.generator) {
+        if (node.async) {
+          // Async generator
+          if (state.opts.asyncGenerators === false) return;
+        } else {
+          // Plain generator
+          if (state.opts.generators === false) return;
+        }
+      } else if (node.async) {
+        // Async function
+        if (state.opts.async === false) return;
       } else {
-        innerBody.push(node);
+        // Not a generator or async function.
+        return;
       }
-    });
 
-    if (outerBody.length > 0) {
-      // Only replace the inner body if we actually hoisted any statements
-      // to the outer body.
-      bodyPath.replace(innerBody);
+      if (node.expression) {
+        // Transform expression lambdas into normal functions.
+        node.expression = false;
+        node.body = t.blockStatement([
+          t.returnStatement(node.body)
+        ]);
+      }
+
+      if (node.async) {
+        path.get("body").traverse(awaitVisitor);
+      }
+
+      var bodyBlockPath = path.get("body");
+      var outerBody = [];
+      var innerBody = [];
+
+      bodyBlockPath.get("body").forEach(function(childPath) {
+        var node = childPath.node;
+        if (node && node._blockHoist != null) {
+          outerBody.push(node);
+        } else {
+          innerBody.push(node);
+        }
+      });
+
+      if (outerBody.length > 0) {
+        // Only replace the inner body if we actually hoisted any statements
+        // to the outer body.
+        bodyBlockPath.node.body = innerBody;
+      }
+
+      var outerFnExpr = getOuterFnExpr(path);
+      // Note that getOuterFnExpr has the side-effect of ensuring that the
+      // function has a name (so node.id will always be an Identifier), even
+      // if a temporary name has to be synthesized.
+      t.assertIdentifier(node.id);
+      var innerFnId = t.identifier(node.id.name + "$");
+      var contextId = path.scope.generateUidIdentifier("context");
+      var argsId = path.scope.generateUidIdentifier("args");
+
+      // Turn all declarations into vars, and replace the original
+      // declarations with equivalent assignment expressions.
+      var vars = hoist(path);
+
+      var didRenameArguments = renameArguments(path, argsId);
+      if (didRenameArguments) {
+        vars = vars || t.variableDeclaration("var", []);
+        vars.declarations.push(t.variableDeclarator(
+          argsId, t.identifier("arguments")
+        ));
+      }
+
+      var emitter = new Emitter(contextId);
+      emitter.explode(path.get("body"));
+
+      if (vars && vars.declarations.length > 0) {
+        outerBody.push(vars);
+      }
+
+      var wrapArgs = [
+        emitter.getContextFunction(innerFnId),
+        // Async functions that are not generators don't care about the
+        // outer function because they don't need it to be marked and don't
+        // inherit from its .prototype.
+        node.generator ? outerFnExpr : t.nullLiteral(null),
+        t.thisExpression()
+      ];
+
+      var tryLocsList = emitter.getTryLocsList();
+      if (tryLocsList) {
+        wrapArgs.push(tryLocsList);
+      }
+
+      var wrapCall = t.callExpression(
+        runtimeProperty(node.async ? "async" : "wrap"),
+        wrapArgs
+      );
+
+      outerBody.push(t.returnStatement(wrapCall));
+      node.body = t.blockStatement(outerBody);
+
+      var wasGeneratorFunction = node.generator;
+      if (wasGeneratorFunction) {
+        node.generator = false;
+      }
+
+      if (node.async) {
+        node.async = false;
+      }
+
+      if (wasGeneratorFunction &&
+          t.isExpression(node)) {
+        path.replaceWith(t.callExpression(runtimeProperty("mark"), [node]));
+      }
     }
-
-    var outerFnExpr = getOuterFnExpr(path);
-    // Note that getOuterFnExpr has the side-effect of ensuring that the
-    // function has a name (so node.id will always be an Identifier), even
-    // if a temporary name has to be synthesized.
-    n.Identifier.assert(node.id);
-    var innerFnId = b.identifier(node.id.name + "$");
-    var contextId = path.scope.declareTemporary("context$");
-    var argsId = path.scope.declareTemporary("args$");
-
-    // Turn all declarations into vars, and replace the original
-    // declarations with equivalent assignment expressions.
-    var vars = hoist(path);
-
-    var didRenameArguments = renameArguments(path, argsId);
-    if (didRenameArguments) {
-      vars = vars || b.variableDeclaration("var", []);
-      vars.declarations.push(b.variableDeclarator(
-        argsId, b.identifier("arguments")
-      ));
-    }
-
-    var emitter = new Emitter(contextId);
-    emitter.explode(path.get("body"));
-
-    if (vars && vars.declarations.length > 0) {
-      outerBody.push(vars);
-    }
-
-    var wrapArgs = [
-      emitter.getContextFunction(innerFnId),
-      // Async functions that are not generators don't care about the
-      // outer function because they don't need it to be marked and don't
-      // inherit from its .prototype.
-      node.generator ? outerFnExpr : b.literal(null),
-      b.thisExpression()
-    ];
-
-    var tryLocsList = emitter.getTryLocsList();
-    if (tryLocsList) {
-      wrapArgs.push(tryLocsList);
-    }
-
-    var wrapCall = b.callExpression(
-      runtimeProperty(shouldTransformAsync ? "async" : "wrap"),
-      wrapArgs
-    );
-
-    outerBody.push(b.returnStatement(wrapCall));
-    node.body = b.blockStatement(outerBody);
-
-    var wasGeneratorFunction = node.generator;
-    if (wasGeneratorFunction) {
-      node.generator = false;
-    }
-
-    if (shouldTransformAsync) {
-      node.async = false;
-    }
-
-    if (wasGeneratorFunction &&
-        n.Expression.check(node)) {
-      return b.callExpression(runtimeProperty("mark"), [node]);
-    }
-  },
-
-  visitForOfStatement: function(path) {
-    this.traverse(path);
-
-    var node = path.value;
-    var tempIterId = path.scope.declareTemporary("t$");
-    var tempIterDecl = b.variableDeclarator(
-      tempIterId,
-      b.callExpression(
-        runtimeProperty("values"),
-        [node.right]
-      )
-    );
-
-    var tempInfoId = path.scope.declareTemporary("t$");
-    var tempInfoDecl = b.variableDeclarator(tempInfoId, null);
-
-    var init = node.left;
-    var loopId;
-    if (n.VariableDeclaration.check(init)) {
-      loopId = init.declarations[0].id;
-      init.declarations.push(tempIterDecl, tempInfoDecl);
-    } else {
-      loopId = init;
-      init = b.variableDeclaration("var", [
-        tempIterDecl,
-        tempInfoDecl
-      ]);
-    }
-    n.Identifier.assert(loopId);
-
-    var loopIdAssignExprStmt = b.expressionStatement(
-      b.assignmentExpression(
-        "=",
-        loopId,
-        b.memberExpression(
-          tempInfoId,
-          b.identifier("value"),
-          false
-        )
-      )
-    );
-
-    if (n.BlockStatement.check(node.body)) {
-      node.body.body.unshift(loopIdAssignExprStmt);
-    } else {
-      node.body = b.blockStatement([
-        loopIdAssignExprStmt,
-        node.body
-      ]);
-    }
-
-    return b.forStatement(
-      init,
-      b.unaryExpression(
-        "!",
-        b.memberExpression(
-          b.assignmentExpression(
-            "=",
-            tempInfoId,
-            b.callExpression(
-              b.memberExpression(
-                tempIterId,
-                b.identifier("next"),
-                false
-              ),
-              []
-            )
-          ),
-          b.identifier("done"),
-          false
-        )
-      ),
-      null,
-      node.body
-    );
   }
-});
+};
 
 // Given a NodePath for a Function, return an Expression node that can be
 // used to refer reliably to the function object from inside the function.
 // This expression is essentially a replacement for arguments.callee, with
 // the key advantage that it works in strict mode.
 function getOuterFnExpr(funPath) {
-  var node = funPath.value;
-  n.Function.assert(node);
+  var node = funPath.node;
+  t.assertFunction(node);
 
   if (node.generator && // Non-generator functions don't need to be marked.
-      n.FunctionDeclaration.check(node)) {
-    var pp = funPath.parent;
-
-    while (pp && !(n.BlockStatement.check(pp.value) ||
-                   n.Program.check(pp.value))) {
-      pp = pp.parent;
-    }
+      t.isFunctionDeclaration(node)) {
+    var pp = funPath.findParent(function (path) {
+      return path.isProgram() || path.isBlockStatement();
+    });
 
     if (!pp) {
       return node.id;
@@ -271,40 +159,40 @@ function getOuterFnExpr(funPath) {
     var markDecl = getRuntimeMarkDecl(pp);
     var markedArray = markDecl.declarations[0].id;
     var funDeclIdArray = markDecl.declarations[0].init.callee.object;
-    n.ArrayExpression.assert(funDeclIdArray);
+    t.assertArrayExpression(funDeclIdArray);
 
     var index = funDeclIdArray.elements.length;
     funDeclIdArray.elements.push(node.id);
 
-    return b.memberExpression(
+    return t.memberExpression(
       markedArray,
-      b.literal(index),
+      t.numberLiteral(index),
       true
     );
   }
 
   return node.id || (
-    node.id = funPath.scope.parent.declareTemporary("callee$")
+    node.id = funPath.scope.parent.generateUidIdentifier("callee")
   );
 }
 
 function getRuntimeMarkDecl(blockPath) {
-  assert.ok(blockPath instanceof NodePath);
+  assert.ok(blockPath instanceof traverse.NodePath);
   var block = blockPath.node;
-  isArray.assert(block.body);
+  assert.ok(Array.isArray(block.body));
 
   var info = getMarkInfo(block);
   if (info.decl) {
     return info.decl;
   }
 
-  info.decl = b.variableDeclaration("var", [
-    b.variableDeclarator(
-      blockPath.scope.declareTemporary("marked"),
-      b.callExpression(
-        b.memberExpression(
-          b.arrayExpression([]),
-          b.identifier("map"),
+  info.decl = t.variableDeclaration("var", [
+    t.variableDeclarator(
+      blockPath.scope.generateUidIdentifier("marked"),
+      t.callExpression(
+        t.memberExpression(
+          t.arrayExpression([]),
+          t.identifier("map"),
           false
         ),
         [runtimeProperty("mark")]
@@ -312,92 +200,59 @@ function getRuntimeMarkDecl(blockPath) {
     )
   ]);
 
-  for (var i = 0; i < block.body.length; ++i) {
-    if (!shouldNotHoistAbove(blockPath.get("body", i))) {
-      break;
-    }
-  }
-
-  blockPath.get("body").insertAt(i, info.decl);
+  blockPath.unshiftContainer("body", info.decl);
 
   return info.decl;
 }
 
-function shouldNotHoistAbove(stmtPath) {
-  var value = stmtPath.value;
-  n.Statement.assert(value);
-
-  // If the first statement is a "use strict" declaration, make sure to
-  // insert hoisted declarations afterwards.
-  return n.ExpressionStatement.check(value) &&
-    n.Literal.check(value.expression) &&
-    value.expression.value === "use strict";
-}
-
 function renameArguments(funcPath, argsId) {
-  assert.ok(funcPath instanceof types.NodePath);
-  var func = funcPath.value;
-  var didRenameArguments = false;
+  assert.ok(funcPath instanceof traverse.NodePath);
 
-  recast.visit(funcPath, {
-    visitFunction: function(path) {
-      if (path.value === func) {
-        this.traverse(path);
-      } else {
-        return false;
-      }
-    },
+  var state = {
+    didRenameArguments: false,
+    argsId: argsId
+  };
 
-    visitIdentifier: function(path) {
-      if (path.value.name === "arguments" &&
-          util.isReference(path)) {
-        path.replace(argsId);
-        didRenameArguments = true;
-        return false;
-      }
-
-      this.traverse(path);
-    }
-  });
+  funcPath.traverse(argumentsVisitor, state);
 
   // If the traversal replaced any arguments references, then we need to
   // alias the outer function's arguments binding (be it the implicit
   // arguments object or some other parameter or variable) to the variable
   // named by argsId.
-  return didRenameArguments;
+  return state.didRenameArguments;
 }
 
-var awaitVisitor = types.PathVisitor.fromMethodsObject({
-  visitFunction: function(path) {
-    return false; // Don't descend into nested function scopes.
+var argumentsVisitor = {
+  "FunctionExpression|FunctionDeclaration": function(path) {
+    path.skip();
   },
 
-  visitAwaitExpression: function(path) {
-    // Convert await and await* expressions to yield expressions.
-    var argument = path.value.argument;
-
-    // If the parser supports await* syntax using a boolean .all property
-    // (#171), desugar that syntax to yield Promise.all(argument).
-    if (path.value.all) {
-      argument = b.callExpression(
-        b.memberExpression(
-          b.identifier("Promise"),
-          b.identifier("all"),
-          false
-        ),
-        [argument]
-      );
+  Identifier: function(path, state) {
+    if (path.node.name === "arguments" && util.isReference(path)) {
+      path.replaceWith(state.argsId);
+      state.didRenameArguments = true;
     }
+  }
+};
+
+var awaitVisitor = {
+  Function: function(path) {
+    path.skip(); // Don't descend into nested function scopes.
+  },
+
+  AwaitExpression: function(path) {
+    // Convert await and await* expressions to yield expressions.
+    var argument = path.node.argument;
 
     // Transforming `await x` to `yield regeneratorRuntime.awrap(x)`
     // causes the argument to be wrapped in such a way that the runtime
     // can distinguish between awaited and merely yielded values.
-    return b.yieldExpression(
-      b.callExpression(
+    path.replaceWith(t.yieldExpression(
+      t.callExpression(
         runtimeProperty("awrap"),
         [argument]
       ),
       false
-    );
+    ));
   }
-});
+};

--- a/package.json
+++ b/package.json
@@ -29,10 +29,14 @@
   },
   "dependencies": {
     "commoner": "~0.10.3",
-    "defs": "~1.1.0",
-    "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+    "babel-plugin-transform-es2015-block-scoping": "^5.0.0",
+    "babel-plugin-syntax-async-functions": "^5.0.0",
+    "babel-plugin-transform-es2015-for-of": "^5.0.0",
+    "babel-core": "^6.0.0",
+    "babel-traverse": "^6.0.0",
+    "babel-types": "^6.0.0",
+    "babylon": "^6.0.0",
     "private": "~0.1.5",
-    "recast": "0.10.33",
     "through": "~2.3.8"
   },
   "devDependencies": {

--- a/test/async.es6.js
+++ b/test/async.es6.js
@@ -266,7 +266,7 @@ describe("async generator functions", function() {
       markers.push(1);
       var result = await sent;
       markers.push(2);
-      assert.strictEqual(await yield "second", "sent after second");
+      assert.strictEqual(await (yield "second"), "sent after second");
       markers.push(3);
       return result;
     }

--- a/test/run.js
+++ b/test/run.js
@@ -139,17 +139,6 @@ enqueue("./bin/regenerator", [
   "./test/async.es5.js"
 ], true);
 
-enqueue("./bin/regenerator", [
-  "--disable-async",
-  "./test/async.es5.js"
-], true);
-
-enqueue("./bin/regenerator", [
-  "--include-runtime",
-  "--disable-async",
-  "./test/async.es5.js"
-], true);
-
 // Make sure we run the command-line tool on a file that does not need any
 // transformation, too.
 
@@ -159,17 +148,6 @@ enqueue("./bin/regenerator", [
 
 enqueue("./bin/regenerator", [
   "--include-runtime",
-  "./test/nothing-to-transform.js"
-], true);
-
-enqueue("./bin/regenerator", [
-  "--disable-async",
-  "./test/nothing-to-transform.js"
-], true);
-
-enqueue("./bin/regenerator", [
-  "--include-runtime",
-  "--disable-async",
   "./test/nothing-to-transform.js"
 ], true);
 


### PR DESCRIPTION
This is  WIP. There are currently ~8 failing tests so I thought I'd put it up for review before I look into them too much. This will heavily improve Babel performance and stability.  I know there are ways for regenerator to perform it's compilation in a single pass in the future too (right now there are a few visitors that are ran independently).

NOTE: This wont currently run unless you've got a `development` branch locally checked out and everything linked which is a bit of a PITA.

AFAIK this was :+1: between @benjamn and @amasad.

TODO:
- [ ] Add back `includeRuntime` option.
- [x] Add back `regenerator.transform` API.
