### PR TITLE
Use SPDX license ID in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "promise": "~7.0.4",
     "semver": "~5.0.3"
   },
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "engines": {
     "node": ">= 0.6"
   }


### PR DESCRIPTION
Do you have any objection? (FWIW it came to my attention while running builds of Babel because the npm warning about it keeps popping up. It'd be nice to eliminate the noise [which I don't expect this to do directly, but that's besides the point].)

Also FWIW, [`LICENSE`](https://github.com/facebook/regenerator/blob/a0fb45fe4060ea93dec7cb93e664114e4e2cdacf/LICENSE) here has bullet-pointed clauses while other versions of the license have numbers:

http://opensource.org/licenses/BSD-2-Clause

https://spdx.org/licenses/BSD-2-Clause.html
