### PR TITLE
Adds failing test for subscripting operator

### DIFF
--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -92,6 +92,12 @@ describe("simple argument yielder", function() {
     itr.next();
     itr.next(1);
     assert.equal(itr.next(2).value, 3);
+    
+    function *gen2() { return (yield null)[yield null]; }
+    var itr2 = gen2();
+    itr2.next();
+    itr2.next({propName: 1234});
+    assert.equal(itr2.next('propName').value, 1234);
   });
 });
 


### PR DESCRIPTION
When both operands to the subscription operator are yield expressions, it does not compile correctly.  The latter expression (the index) is erroneously used for both operands.