### PR TITLE
Bump commoner version to ~0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "node test/run.js"
   },
   "dependencies": {
-    "commoner": "~0.10.3",
+    "commoner": "~0.10.4",
     "defs": "~1.1.0",
     "esprima-fb": "~15001.1001.0-dev-harmony-fb",
     "private": "~0.1.5",


### PR DESCRIPTION
Fix WARN

```
npm WARN deprecated graceful-fs@3.0.8: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
```
