### PR TITLE
Minimise cases inside the regenerator FSM

### DIFF
--- a/lib/emit.js
+++ b/lib/emit.js
@@ -234,6 +234,11 @@ Ep.getDispatchLoop = function() {
   // case, we can skip the rest of the statements until the next case.
   var alreadyEnded = false;
 
+  // Check if the listing entry is an abrupt return; if last thing in listing is
+  // one, then no need an additional case to be added.
+  var wasAbruptReturn = false;
+  var lastListingIndex = self.listing.length - 1;
+
   self.listing.forEach(function(stmt, i) {
     if (self.marked.hasOwnProperty(i)) {
       cases.push(b.switchCase(
@@ -247,17 +252,24 @@ Ep.getDispatchLoop = function() {
       if (isSwitchCaseEnder(stmt))
         alreadyEnded = true;
     }
+
+    wasAbruptReturn = i === lastListingIndex
+      && checkAbruptReturn(stmt, self.contextId);
   });
 
   // Now that we know how many statements there will be in this.listing,
   // we can finally resolve this.finalLoc.value.
   this.finalLoc.value = this.listing.length;
 
-  cases.push(
-    b.switchCase(this.finalLoc, [
-      // Intentionally fall through to the "end" case...
-    ]),
+  if (!wasAbruptReturn) {
+    cases.push(
+      b.switchCase(this.finalLoc, [
+        // Intentionally fall through to the "end" case...
+      ])
+    );
+  }
 
+  cases.push(
     // So that the runtime can jump to the final location without having
     // to know its offset, we provide the "end" case as a synonym.
     b.switchCase(b.literal("end"), [
@@ -287,6 +299,17 @@ function isSwitchCaseEnder(stmt) {
       || n.ContinueStatement.check(stmt)
       || n.ReturnStatement.check(stmt)
       || n.ThrowStatement.check(stmt);
+}
+
+// See comment above re: wasAbruptReturn.
+function checkAbruptReturn(stmt, contextId) {
+  // Abrupt if stmt like `return context.abrupt('return', ...);`
+  return n.ReturnStatement.check(stmt)
+      && n.CallExpression.check(stmt.argument)
+      && stmt.argument.callee.object === contextId
+      && stmt.argument.callee.property.name === 'abrupt'
+      && n.Literal.check(stmt.argument.arguments[0])
+      && stmt.argument.arguments[0].value === 'return';
 }
 
 Ep.getTryLocsList = function() {

--- a/lib/emit.js
+++ b/lib/emit.js
@@ -304,12 +304,12 @@ function isSwitchCaseEnder(stmt) {
 // See comment above re: wasAbruptReturn.
 function checkAbruptReturn(stmt, contextId) {
   // Abrupt if stmt like `return context.abrupt('return', ...);`
-  return n.ReturnStatement.check(stmt)
+  return n.ThrowStatement.check(stmt) || (n.ReturnStatement.check(stmt)
       && n.CallExpression.check(stmt.argument)
       && stmt.argument.callee.object === contextId
       && stmt.argument.callee.property.name === 'abrupt'
       && n.Literal.check(stmt.argument.arguments[0])
-      && stmt.argument.arguments[0].value === 'return';
+      && stmt.argument.arguments[0].value === 'return');
 }
 
 Ep.getTryLocsList = function() {

--- a/test/tests.transform.js
+++ b/test/tests.transform.js
@@ -47,7 +47,7 @@ describe("_blockHoist nodes", function() {
 });
 
 describe("awaiting result", function() {
-  it("should not use unnecessary cases", function() {
+  it("should not use unnecessary cases when returning", function() {
     var parsed = recast.parse([
       "async function foo(bar) {",
       "  return await bar();",
@@ -64,6 +64,9 @@ describe("awaiting result", function() {
     assert.deepEqual(whileStmt.type, "WhileStatement");
     var switchStmt = whileStmt.body;
     assert.deepEqual(switchStmt.type, "SwitchStatement");
+    // 1. setup
+    // 2. returning await
+    // 3. `end`
     assert.deepEqual(switchStmt.cases.length, 3);
 
     // Sense-check the behaviour of this function
@@ -75,6 +78,36 @@ describe("awaiting result", function() {
     });
     return resultPromise.then(function (promiseResolution) {
       assert.strictEqual(promiseResolution, "finished");
+    });
+  });
+
+  it("should not use unnecessary cases when throwing", function() {
+    var parsed = recast.parse([
+      "async function foo() {",
+      "  throw new Error();",
+      "}"
+    ].join("\n"));
+
+    var afterTransformation = transform(parsed);
+
+    // Dive into transformed AST and confirm the number of case statements used
+    // in the inner FSM.
+    var returnStmt = afterTransformation.program.body[0].body.body[0];
+    assert.deepEqual(returnStmt.type, "ReturnStatement");
+    var whileStmt = returnStmt.argument.arguments[0].body.body[0];
+    assert.deepEqual(whileStmt.type, "WhileStatement");
+    var switchStmt = whileStmt.body;
+    assert.deepEqual(switchStmt.type, "SwitchStatement");
+    // 1. setup and throw
+    // 2. end
+    assert.deepEqual(switchStmt.cases.length, 2);
+
+    // Sense-check the behaviour of this function
+    eval(recast.print(parsed).code);
+    assert.strictEqual(typeof foo, "function");
+
+    return foo().catch(function (error) {
+      assert(error instanceof Error);
     });
   });
 });


### PR DESCRIPTION
(NB: Also at babel/babel#3462 )

This PR aids downstream consumers of optimised code by producing a more idomatic switch statement in the regenerator FSM used for generators/async statements.

This greatly benefits code coverage tools that check for branch usage; as-is, it's not possible to cover every branch.