### PR TITLE
Allow Browserify to handle regenerator errors #20

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,8 +28,10 @@ function exports(file, options) {
   }
 
   function end() {
-    this.queue(compile(data.join(""), options).code);
-    this.queue(null);
+    try {
+      this.queue(compile(data.join(""), options).code);
+      this.queue(null);
+    } catch (e) { this.emit('error', e); }
   }
 }
 


### PR DESCRIPTION
via #20 

At the moment it seems it's not possible to handle errors emitted on a regenerator transformation through browserify.

So:

```js
browserify(src)
   .transform(require('regenerator'))
   .bundle(function (err, bundle) {
       if (err) { return handleError(err); }
       handleBundle(bundle);
   });
```

where `handleError` never gets triggered and the application crashes beforehand because apparently regenerator is throwing an Error instead of emitting through this.emit('error', new Error())

more on how to achieve this: 
https://github.com/substack/node-browserify/blob/071642ad9cbb44cb530d43edfac17c5077a9442c/test/tr_error.js#L11-L13