### PR TITLE
Feature/use scoped promise

### DIFF
--- a/lib/visit.js
+++ b/lib/visit.js
@@ -138,13 +138,10 @@ var visitor = types.PathVisitor.fromMethodsObject({
       // outer function because they don't need it to be marked and don't
       // inherit from its .prototype.
       node.generator ? outerFnExpr : b.literal(null),
-      b.thisExpression()
+      b.thisExpression(),
+      emitter.getTryLocsList() || b.identifier("void 0"),
+      b.identifier("Promise")
     ];
-
-    var tryLocsList = emitter.getTryLocsList();
-    if (tryLocsList) {
-      wrapArgs.push(tryLocsList);
-    }
 
     var wrapCall = b.callExpression(
       runtimeProperty(shouldTransformAsync ? "async" : "wrap"),

--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -133,7 +133,7 @@
     this.arg = arg;
   }
 
-  function AsyncIterator(generator) {
+  function AsyncIterator(generator,Promise) {
     function invoke(method, arg, resolve, reject) {
       var record = tryCatch(generator[method], generator, arg);
       if (record.type === "throw") {
@@ -215,9 +215,10 @@
   // Note that simple async functions are implemented on top of
   // AsyncIterator objects; they just return a Promise for the value of
   // the final result produced by the iterator.
-  runtime.async = function(innerFn, outerFn, self, tryLocsList) {
+  runtime.async = function(innerFn, outerFn, self, tryLocsList, Promise) {
     var iter = new AsyncIterator(
-      wrap(innerFn, outerFn, self, tryLocsList)
+      wrap(innerFn, outerFn, self, tryLocsList),
+      Promise
     );
 
     return runtime.isGeneratorFunction(outerFn)

--- a/test/async.es6.js
+++ b/test/async.es6.js
@@ -23,6 +23,26 @@ describe("async functions and await expressions", function() {
     it("should have a .wrap method", function() {
       assert.strictEqual(typeof regeneratorRuntime.wrap, "function");
     });
+	
+    it("should use local scope's promise", function() {
+        var global = Function("return this")();
+        function Promise(fn){
+    
+        }
+        Promise.prototype = {
+          then: function(fn){
+            return new Promise();
+          }
+        }
+        
+        async function myFunc(){
+        
+        }
+        var result = myFunc();
+        var proto = Object.getPrototypeOf(result);
+        assert.ok(proto == Promise.prototype);
+        assert.ok(proto != global.Promise.prototype);
+    });
   });
 
   describe("Promise", function() {


### PR DESCRIPTION
I had read that async functions are supposed to use the current scopes Promise constructor when creating Promises. I wasn't able to find this in the actual [proposal](https://tc39.github.io/ecmascript-asyncawait/) but I didn't extensively read it over. At any rate, I think it makes sense that an async function should use the current scope's Promise.