### PR TITLE
Fix generator prototype chain to more correctly match ES2015 spec

### DIFF
--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -11,7 +11,8 @@
 !(function(global) {
   "use strict";
 
-  var hasOwn = Object.prototype.hasOwnProperty;
+  var Op = Object.prototype;
+  var hasOwn = Op.hasOwnProperty;
   var undefined; // More compressible than void 0.
   var $Symbol = typeof Symbol === "function" ? Symbol : {};
   var iteratorSymbol = $Symbol.iterator || "@@iterator";
@@ -83,26 +84,29 @@
   function GeneratorFunction() {}
   function GeneratorFunctionPrototype() {}
 
-  // this is a polyfill for %IteratorPrototype% for environments that don't
-  // natively support it.
+  // This is a polyfill for %IteratorPrototype% for environments that
+  // don't natively support it.
   var IteratorPrototype = {};
-  IteratorPrototype[iteratorSymbol] = function() {return this;};
+  IteratorPrototype[iteratorSymbol] = function () {
+    return this;
+  };
+
   var getProto = Object.getPrototypeOf;
-  if (getProto) {
-    var NativeIteratorPrototype = getProto(getProto(values([])));
-    if (NativeIteratorPrototype &&
-      NativeIteratorPrototype !== Object.prototype &&
-      NativeIteratorPrototype.hasOwnProperty(iteratorSymbol)) {
-      // this environment has a native %IteratorPrototype%; use it instead of
-      // a polyfill.
-      IteratorPrototype = NativeIteratorPrototype;
-    }
+  var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
+  if (NativeIteratorPrototype &&
+      NativeIteratorPrototype !== Op &&
+      hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
+    // This environment has a native %IteratorPrototype%; use it instead
+    // of the polyfill.
+    IteratorPrototype = NativeIteratorPrototype;
   }
 
-  var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype);
+  var Gp = GeneratorFunctionPrototype.prototype =
+    Generator.prototype = Object.create(IteratorPrototype);
   GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
   GeneratorFunctionPrototype.constructor = GeneratorFunction;
-  GeneratorFunctionPrototype[toStringTagSymbol] = GeneratorFunction.displayName = "GeneratorFunction";
+  GeneratorFunctionPrototype[toStringTagSymbol] =
+    GeneratorFunction.displayName = "GeneratorFunction";
 
   // Helper for defining the .next, .throw, and .return methods of the
   // Iterator interface in terms of a single ._invoke method.

--- a/test/non-native.js
+++ b/test/non-native.js
@@ -12,9 +12,9 @@ describe("@@iterator", function() {
     var iterator = gen();
     assert.ok(!iterator.hasOwnProperty(Symbol.iterator));
     assert.ok(!Object.getPrototypeOf(iterator).hasOwnProperty(Symbol.iterator));
-    assert.ok(Object.getPrototypeOf(
+    assert.ok(Object.getPrototypeOf(Object.getPrototypeOf(
       Object.getPrototypeOf(iterator)
-    ).hasOwnProperty(Symbol.iterator));
+    )).hasOwnProperty(Symbol.iterator));
     assert.strictEqual(iterator[Symbol.iterator](), iterator);
   });
 });


### PR DESCRIPTION
Thanks so much for your work on such a cool project!

I found what I think is a spec-compliance bug with the generator prototype chain. According to section 25.3.1 (emphasis mine):

> The Generator prototype object is the %GeneratorPrototype% intrinsic. It is also the initial value of the prototype property of the %Generator% intrinsic (the GeneratorFunction.prototype).
> 
> &lt;snip&gt;
> 
> **The value of the [[Prototype]] internal slot of the Generator prototype object is the intrinsic object %IteratorPrototype% (25.1.2)**. The initial value of the [[Extensible]] internal slot of the Generator prototype object is true.

This means that` %GeneratorPrototype%` should **not** have a `Symbol.iterator` property, but its prototype should. In addition, `%GeneratorPrototype%'`s prototype should be the same as the prototype of `%ArrayIteratorPrototype%`, `%MapIteratorPrototype%`, `%SetIteratorPrototype%`, and `%StringIteratorPrototype%`.

In the current code base, though, `%GeneratorPrototype%` (called `Gp` in the code) is given a `Symbol.iterator` property and has its prototype set to `Object.prototype`. As I found out in [a PR to core-js](https://github.com/zloirock/core-js/pull/261), some older browsers that support iterators evidently don't have `%IteratorPrototype%`, so this behavior is reasonable in those browsers, but I think it should probably be correct in browsers that do have `%IteratorPrototype%`.

This PR changes the unit test that checks the prototype chain for a `Symbol.iterator` property. The current test implementation is not spec-compliant and fails in both currently shipping Chrome and Firefox.

In this patch, if `%IteratorPrototype%` can't be found, it falls back to the existing behavior.

Again, thanks so much for this project, and please let me know what I can do to improve this PR!