### PR TITLE
compile with loose mode

### DIFF
--- a/packages/regenerator-transform/package.json
+++ b/packages/regenerator-transform/package.json
@@ -20,7 +20,7 @@
   },
   "babel": {
     "presets": [
-      ["es2015", { loose: true }]
+      ["es2015", { "loose": true }]
     ],
     "plugins": [
       "transform-runtime"

--- a/packages/regenerator-transform/package.json
+++ b/packages/regenerator-transform/package.json
@@ -20,7 +20,7 @@
   },
   "babel": {
     "presets": [
-      "es2015"
+      ["es2015", { loose: true }]
     ],
     "plugins": [
       "transform-runtime"


### PR DESCRIPTION
If we move the implementation maybe we want to be as close as possible to what it was before?

https://github.com/babel/babel/blob/26b4e0909ef8ec3a45b08f2a475124ed83defdac/package.json#L51-L66

```
{
"comments": false,
    "presets": [
      [
        "es2015",
        {
          "loose": true
        }
      ],
      "stage-0"
    ],
    "plugins": [
      "./scripts/add-module-exports",
      "transform-runtime",
      "transform-class-properties",
      "transform-flow-strip-types"
    ],
}

the other plugins/presets won't matter if the syntax isn't used so we can ignore that.