### PR TITLE
Fix for bug when transform-regenerator is run without transform-es2015-shorthand-properties

### DIFF
--- a/packages/regenerator-transform/src/replaceShorthandObjectMethod.js
+++ b/packages/regenerator-transform/src/replaceShorthandObjectMethod.js
@@ -1,0 +1,73 @@
+import * as t from "babel-types";
+
+// this function converts a shorthand object generator method into a normal
+// (non-shorthand) object property which is a generator function expression. for
+// example, this:
+//
+//  var foo = {
+//    *bar(baz) { return 5; }
+//  }
+//
+// should be replaced with:
+//
+//  var foo = {
+//    bar: function*(baz) { return 5; }
+//  }
+//
+// to do this, it clones the parameter array and the body of the object generator
+// method into a new FunctionExpression.
+//
+// this method can be passed any Function AST node path, and it will return
+// either:
+//   a) the path that was passed in (iff the path did not need to be replaced) or
+//   b) the path of the new FunctionExpression that was created as a replacement
+//     (iff the path did need to be replaced)
+//
+// In either case, though, the caller can count on the fact that the return value
+// is a Function AST node path.
+//
+// If this function is called with an AST node path that is not a Function (or with an
+// argument that isn't an AST node path), it will throw an error.
+export default function replaceShorthandObjectMethod(path) {
+  if (!path.node || !t.isFunction(path.node)) {
+    throw new Error("replaceShorthandObjectMethod can only be called on Function AST node paths.");
+  }
+
+  // this function only replaces shorthand object methods (called ObjectMethod
+  // in Babel-speak).
+  if (!t.isObjectMethod(path.node)) {
+    return path;
+  }
+
+  // this function only replaces generators.
+  if (!path.node.generator) {
+    return path;
+  }
+
+  const parameters = path.node.params.map(function (param) {
+    return t.cloneDeep(param);
+  })
+
+  const functionExpression = t.functionExpression(
+    null, // id
+    parameters, // params
+    t.cloneDeep(path.node.body), // body
+    path.node.generator,
+    path.node.async
+  );
+
+  path.replaceWith(
+    t.objectProperty(
+      t.cloneDeep(path.node.key), // key
+      functionExpression, //value
+      path.node.computed, // computed
+      false // shorthand
+    )
+  );
+
+  // path now refers to the ObjectProperty AST node path, but we want to return a
+  // Function AST node path for the function expression we created. we know that
+  // the FunctionExpression we just created is the value of the ObjectProperty,
+  // so return the "value" path off of this path.
+  return path.get("value");
+}

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -16,6 +16,53 @@ import * as util from "./util";
 
 let getMarkInfo = require("private").makeAccessor();
 
+// we want to convert this shorthand object method into a normal object property
+// which is a function expression. for example, this:
+//  var foo = {
+//    *bar(baz) { return 5; }
+//  }
+// should be replaced with:
+//  var foo = {
+//    bar: function*(baz) { return 5; }
+//  }
+// to do this, we will clone the parameter array and the body of the function
+// into a new FunctionExpression.
+function replaceShorthandObjectMethod(path) {
+  if (!t.isObjectMethod(path.node)) {
+    return path;
+  }
+
+  // if it's not a generator method, we don't need to do anything.
+  if (!path.node.generator) {
+    return path;
+  }
+
+  const parameters = path.node.params.map(function (param) {
+    return t.cloneDeep(param);
+  })
+
+  if (!(path.node.key.name || path.node.key.value)) throw path.node.key;
+  const functionExpression = t.functionExpression(
+    null, // id
+    parameters, // params
+    t.cloneDeep(path.node.body), // body
+    path.node.generator,
+    path.node.async
+  );
+
+  path.replaceWith(
+    t.objectProperty(
+      t.cloneDeep(path.node.key), // key
+      functionExpression, //value
+      path.node.computed, // computed
+      false // shorthand
+    )
+  );
+
+  // return the function expression path.
+  return path.get("value");
+}
+
 exports.visitor = {
   Function: {
     exit: function(path, state) {
@@ -36,6 +83,10 @@ exports.visitor = {
         // Not a generator or async function.
         return;
       }
+
+      // if this is an ObjectMethod, we need to convert it to an ObjectProperty
+      path = replaceShorthandObjectMethod(path);
+      node = path.node;
 
       let contextId = path.scope.generateUidIdentifier("context");
       let argsId = path.scope.generateUidIdentifier("args");

--- a/test/run.js
+++ b/test/run.js
@@ -92,10 +92,31 @@ if (semver.gte(process.version, "0.11.2")) {
   ]);
 }
 
+if (semver.gte(process.version, "4.0.0")) {
+  enqueue("mocha", [
+    "--harmony",
+    "--reporter", "spec",
+    "--require", "./test/runtime.js",
+    "./test/tests-node4.es6.js",
+  ]);
+}
+
 enqueue(convert, [
   "./test/tests.es6.js",
   "./test/tests.es5.js"
 ]);
+
+if (semver.gte(process.version, "4.0.0")) {
+  enqueue(convert, [
+    "./test/tests-node4.es6.js",
+    "./test/tests-node4.es5.js"
+  ]);
+} else {
+  // we are on an older platform, but we still need to create an empty
+  // tests-node4.es5.js file so that the test commands below have a file to refer
+  // to.
+  fs.writeFileSync("./test/tests-node4.es5.js", "");
+}
 
 enqueue(convert, [
   "./test/non-native.js",
@@ -118,6 +139,7 @@ if (!semver.eq(process.version, "0.11.7")) {
     enqueue(bundle, [
       ["./test/runtime.js",
        "./test/tests.es5.js",
+       "./test/tests-node4.es5.js",
        "./test/non-native.es5.js",
        "./test/async.es5.js"],
       "./test/tests.browser.js"
@@ -131,6 +153,7 @@ enqueue("mocha", [
   "--reporter", "spec",
   "--require", "./test/runtime.js",
   "./test/tests.es5.js",
+  "./test/tests-node4.es5.js",
   "./test/non-native.es5.js",
   "./test/async.es5.js",
   "./test/tests.transform.js"

--- a/test/tests-node4.es6.js
+++ b/test/tests-node4.es6.js
@@ -1,0 +1,38 @@
+// tests that should be run only in node 4 and higher, as they use
+// language features not supported by versions < 4 (even with --harmony).
+var shared = require("./shared.js");
+var check = shared.check;
+
+describe("object properties", function () {
+  it("should work if the generator is a simple object property", function () {
+    var obj = {
+      gen: function*(x) {
+        yield x;
+      }
+    };
+
+    check(obj.gen("oyez"), ["oyez"]);
+  });
+
+  it("should work if the generator is a shorthand object method", function () {
+    var obj = {
+      *gen(x) {
+        yield x;
+      }
+    };
+
+    check(obj.gen("oyez"), ["oyez"]);
+  });
+
+  it("should work if the generator is a shorthand computed object method", function () {
+    var fnName = "gen";
+    var obj = {
+      *[fnName](x) {
+        yield x;
+      }
+    };
+
+    check(obj.gen("oyez"), ["oyez"]);
+  });
+
+});

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -2403,37 +2403,3 @@ describe("expressions containing yield subexpressions", function() {
     });
   });
 });
-
-describe("object properties", function () {
-  it("should work if the generator is a simple object property", function () {
-    var obj = {
-      gen: function*(x) {
-        yield x;
-      }
-    };
-
-    check(obj.gen("oyez"), ["oyez"]);
-  });
-
-  it("should work if the generator is a shorthand object method", function () {
-    var obj = {
-      *gen(x) {
-        yield x;
-      }
-    };
-
-    check(obj.gen("oyez"), ["oyez"]);
-  });
-
-  it("should work if the generator is a shorthand computed object method", function () {
-    var fnName = "gen";
-    var obj = {
-      *[fnName](x) {
-        yield x;
-      }
-    };
-
-    check(obj.gen("oyez"), ["oyez"]);
-  });
-
-})

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -2403,3 +2403,37 @@ describe("expressions containing yield subexpressions", function() {
     });
   });
 });
+
+describe("object properties", function () {
+  it("should work if the generator is a simple object property", function () {
+    var obj = {
+      gen: function*(x) {
+        yield x;
+      }
+    };
+
+    check(obj.gen("oyez"), ["oyez"]);
+  });
+
+  it("should work if the generator is a shorthand object method", function () {
+    var obj = {
+      *gen(x) {
+        yield x;
+      }
+    };
+
+    check(obj.gen("oyez"), ["oyez"]);
+  });
+
+  it("should work if the generator is a shorthand computed object method", function () {
+    var fnName = "gen";
+    var obj = {
+      *[fnName](x) {
+        yield x;
+      }
+    };
+
+    check(obj.gen("oyez"), ["oyez"]);
+  });
+
+})


### PR DESCRIPTION
I think I found a bug with `transformer-regenerator` when it is used without `transform-es2015-shorthand-properties`. If you take the following input code:

```
var o = {
  *foo() {
    return "foo";
  }
};
```
and apply **only** `transform-regenerator`, you get:
```
var o = {
  foo() {
    return regeneratorRuntime.wrap(function _callee$(_context) {
      while (1) switch (_context.prev = _context.next) {
        case 0:
          return _context.abrupt("return", "foo");

        case 1:
        case "end":
          return _context.stop();
      }
    }, _callee, this);
  }
};
```
Note that there is a reference to `_callee` at the end, but `_callee` is never defined. This causes a ReferenceError when the code is run.

If you add `transform-es2015-shorthand-properties` to the plugin list, you instead get this result:
```
var o = {
  foo: regeneratorRuntime.mark(function _callee() {
    return regeneratorRuntime.wrap(function _callee$(_context) {
      while (1) switch (_context.prev = _context.next) {
        case 0:
          return _context.abrupt("return", "foo");

        case 1:
        case "end":
          return _context.stop();
      }
    }, _callee, this);
  })
};
```
This version does define `_callee`, and it works.

I've been experimenting with doing different builds for different browsers, and there are some browser versions that support shorthand properties but not generators. It would be really nice to use `transform-regenerator` without `transform-es2015-shorthand-properties` in this case.

I made a patch for `transform-regenerator` in this PR that I believe fixes the problem. Since I don't really understand all the intricacies of `regenerator`, I decided to just translate all shorthand generator object methods into non-shorthand object properties with a generator function expression value before the rest of `transform-regenerator` runs. Since generator function expressions transform correctly already, this seems to work.

I added three test cases: 2 with shorthand object methods and 1 with a boring old object property. The shorthand object method test cases failed with the master branch and work with this PR. All other tests pass on my machine, but I'll watch CI to see how the patch does on other platforms.

I fully admit I don't understand all this code perfectly, and I welcome any and all feedback on the patch. Thanks for all your work!