### PR TITLE
update babel-preset-es2015 to 6.18.0

### DIFF
--- a/packages/regenerator-transform/package.json
+++ b/packages/regenerator-transform/package.json
@@ -34,6 +34,6 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-plugin-transform-runtime": "^6.9.0",
-    "babel-preset-es2015": "^6.9.0"
+    "babel-preset-es2015": "^6.18.0"
   }
 }


### PR DESCRIPTION
I am getting an error when I try to run my webpack build.
```
Error in config file!
Error: Options {"loose":true} passed to /Users/my-repo/node_modules/babel-preset-es2015/lib/index.js which does not accept options.
(While processing preset: "/Users/my-repo/node_modules/babel-preset-es2015/lib/index.js")
(While processing preset: "/Users/my-repo/node_modules/babel-preset-es2015/lib/index.js")
```

[This PR](https://github.com/facebook/regenerator/commit/acf11c4218088df58cc7c80d63d5ce2c48e152c7) added `{ "loose": true }` to `es2015` preset, but loose is not supported until [es2015 v6.13.0](https://github.com/babel/babel/blob/master/CHANGELOG.md#v6130-2016-08-04).

I updated `babel-preset-es2015` to latest v6.18.0 and all the tests pass.