### PR TITLE
Update regenerator-runtime package.json

### DIFF
--- a/packages/regenerator-runtime/package.json
+++ b/packages/regenerator-runtime/package.json
@@ -14,5 +14,5 @@
     "type": "git",
     "url": "https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime"
   },
-  "license": "MIT"
+  "license": "BSD"
 }


### PR DESCRIPTION
I guess the license of `regenerator-runtime` is BSD.