### PR TITLE
Add ArrowFunctionExpression to opaqueTypes

### DIFF
--- a/packages/regenerator-transform/src/meta.js
+++ b/packages/regenerator-transform/src/meta.js
@@ -68,7 +68,8 @@ function makePredicate(propertyName, knownTypes) {
 }
 
 let opaqueTypes = {
-  FunctionExpression: true
+  FunctionExpression: true,
+  ArrowFunctionExpression: true
 };
 
 // These types potentially have side effects regardless of what side


### PR DESCRIPTION
Using arrow functions inside generators:
```javascript
function gen* {
  const a = () => { 
    return 1 
  };
};
```
throws:
```
Error: src/index.js: unknown Expression of type "ArrowFunctionExpression"
    at /Users/aqson/Development/temp/babel-preset-env-issue-160/node_modules/regenerator-transform/lib/emit.js:1035:15
```
But works fine with `FunctionExpression`s and arrow functions without `BlockStatement`s:
```
function gen* {
  const a = () => 1;
};

function gen2* {
  const a = function () {
    return 1;
  };
};
```
The root of the problems lies in the `explodeStatement` method where we check [node for the leaps](https://github.com/facebook/regenerator/blob/master/packages/regenerator-transform/src/emit.js#L386) and 2 of working cases returns `false`, but the one with ArrowFunctionExpression + BlockStatement - `true`.

Resolves: https://github.com/babel/babel-preset-env/issues/160 and other cases without `babel-plugin-transform-es2015-arrow-functions`.
