### PR TITLE
Fix hoisting of arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "through": "^2.3.8"
   },
   "devDependencies": {
+    "babel-plugin-transform-es2015-parameters": "^6.23.0",
+    "babel-plugin-transform-es2015-spread": "^6.22.0",
     "babylon": "^6.14.1",
     "mocha": "^2.3.4",
     "promise": "^7.0.4",

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -96,8 +96,11 @@ exports.visitor = {
       let didRenameArguments = renameArguments(path, argsId);
       if (didRenameArguments) {
         vars = vars || t.variableDeclaration("var", []);
+        const argumentIdentifier = t.identifier("arguments");
+        // we need to do this as otherwise arguments in arrow functions gets hoisted
+        argumentIdentifier._shadowedFunctionLiteral = path;
         vars.declarations.push(t.variableDeclarator(
-          argsId, t.identifier("arguments")
+          argsId, argumentIdentifier
         ));
       }
 

--- a/test/regression.js
+++ b/test/regression.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * https://raw.github.com/facebook/regenerator/master/LICENSE file. An
+ * additional grant of patent rights can be found in the PATENTS file in
+ * the same directory.
+ */
+
+var assert = require("assert");
+
+describe("regressions", function() {
+  it("should correctly hoist arguments", async function () {
+    function test(fn) {
+      return async (...args) => {
+        return fn(...args);
+      };
+    }
+    const result = [];
+    await test((arg1, arg2) => { result.push(arg1, arg2); })(1, "foo");
+
+    assert.deepEqual(result, [1, "foo"]);
+  });
+});

--- a/test/run.js
+++ b/test/run.js
@@ -128,6 +128,31 @@ enqueue(convert, [
   "./test/async.es5.js"
 ]);
 
+function convertWithSpread(es6File, es5File, callback) {
+  var transformOptions = {
+    presets:[require("regenerator-preset")],
+    plugins: [
+      require("babel-plugin-transform-es2015-spread"),
+      require("babel-plugin-transform-es2015-parameters")
+    ]
+  };
+
+  fs.readFile(es6File, "utf-8", function(err, es6) {
+    if (err) {
+      return callback(err);
+    }
+
+    var es5 = require("babel-core").transform(es6, transformOptions).code;
+
+    fs.writeFile(es5File, es5, callback);
+  });
+}
+
+enqueue(convertWithSpread, [
+  "./test/regression.js",
+  "./test/regression.es5.js"
+]);
+
 enqueue(makeMochaCopyFunction("mocha.js"));
 enqueue(makeMochaCopyFunction("mocha.css"));
 
@@ -137,11 +162,14 @@ if (!semver.eq(process.version, "0.11.7")) {
   try {
     require.resolve("browserify"); // Throws if missing.
     enqueue(bundle, [
-      ["./test/runtime.js",
-       "./test/tests.es5.js",
-       "./test/tests-node4.es5.js",
-       "./test/non-native.es5.js",
-       "./test/async.es5.js"],
+      [
+        "./test/runtime.js",
+        "./test/tests.es5.js",
+        "./test/tests-node4.es5.js",
+        "./test/non-native.es5.js",
+        "./test/async.es5.js",
+        "./test/regression.es5.js"
+      ],
       "./test/tests.browser.js"
     ]);
   } catch (ignored) {
@@ -156,6 +184,7 @@ enqueue("mocha", [
   "./test/tests-node4.es5.js",
   "./test/non-native.es5.js",
   "./test/async.es5.js",
+  "./test/regression.es5.js",
   "./test/tests.transform.js"
 ]);
 


### PR DESCRIPTION
In the case that the generator or the async function is initially an arrow function and uses only a rest param, the babel es2015 transforms will replace the arrow with a function and the rest param with arguments. regenerator-transform will later also replace and move the arguments. In the end babel will hoist the arguments back up, but to the wrong level.

Thats a little bit complicated to describe, maybe better I show it with code:

1. initial
```js
function test(fn) {
  return async (...args) => {
    return fn(...args);
  };
}
```

2. arrow transform
```js
function test(fn) {
  return async function (...args) {
    return fn(...args);
  };
}
```

3. rest transform
```js
function test(fn) {
  return async function () {
    return fn.apply(this, arguments);
  };
}
```

4. regenerator transform (this is what it should be in the end)
```js
function test(fn) {
  var _this = this;
  return function () {
    var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
      var _args = arguments;
      return regeneratorRuntime.wrap(function _callee$(_context) {
        while (1) {
          switch (_context.prev = _context.next) {
            case 0:
              return _context.abrupt("return", fn.apply(undefined, _args));

            case 1:
            case "end":
              return _context.stop();
          }
        }
      }, _callee, _this);
    }));

    return function () {
      return _ref.apply(this, arguments);
    };
  }();
}
```

5. babel hoist (not exactly sure what is triggering this, maybe another plugin, or babel itself)

> Note that arguments gets hoisted incorrectly

```js
function test(fn) {
  var _arguments = arguments,
      _this = this;

  return function () {
    var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
      var _args = _arguments;
      return regeneratorRuntime.wrap(function _callee$(_context) {
        while (1) {
          switch (_context.prev = _context.next) {
            case 0:
              return _context.abrupt("return", fn.apply(undefined, _args));

            case 1:
            case "end":
              return _context.stop();
          }
        }
      }, _callee, _this);
    }));

    return function () {
      return _ref.apply(this, arguments);
    };
  }();
}
```



This change sets a hint on the `arguments`-identifier to which function it belongs to, and it will only get hoisted up to this level.
We also do this in babel in certain places: https://github.com/babel/babel/blob/7.0/packages/babel-plugin-transform-es2015-parameters/src/rest.js#L212

I tried creating an test, but couldn't find exactly how to do it.

//cc @hzoo @existentialism @loganfsmyth 

Fixes: babel/babel#5485 babel/babel#5330 babel/babel#4219