### PR TITLE
Use babel-preset-env instead of babel-preset-es2015

### DIFF
--- a/packages/regenerator-transform/package.json
+++ b/packages/regenerator-transform/package.json
@@ -20,7 +20,7 @@
   },
   "babel": {
     "presets": [
-      ["es2015", { "loose": true }]
+      ["env", { "loose": true }]
     ],
     "plugins": [
       "transform-runtime"
@@ -34,6 +34,6 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-plugin-transform-runtime": "^6.9.0",
-    "babel-preset-es2015": "^6.18.0"
+    "babel-preset-env": "^1.2.2"
   }
 }


### PR DESCRIPTION
This includes support for es2016 & es2017 and we are also more or less recommending everyone to use env instead of `latest`- or `es20XX`-presets.

If at some point node <4 might be dropped in this package, we could also easily target node4 as environment, which excludes some transforms.

Right now the transformed sourcecode is exactly the same.