### PR TITLE
Don't pass falsy nodes to `path.replaceWith()`

### DIFF
--- a/packages/regenerator-transform/src/emit.js
+++ b/packages/regenerator-transform/src/emit.js
@@ -601,7 +601,7 @@ Ep.explodeStatement = function(path, labelId) {
     }
 
     let discriminant = path.get("discriminant");
-    discriminant.replaceWith(condition);
+    util.replaceWithOrRemove(discriminant, condition);
     self.jump(self.explodeExpression(discriminant));
 
     self.leapManager.withEntry(
@@ -749,7 +749,7 @@ Ep.explodeStatement = function(path, labelId) {
 let catchParamVisitor = {
   Identifier: function(path, state) {
     if (path.node.name === state.catchParamName && util.isReference(path)) {
-      path.replaceWith(state.safeParam);
+      util.replaceWithOrRemove(path, state.safeParam);
     }
   },
 

--- a/packages/regenerator-transform/src/hoist.js
+++ b/packages/regenerator-transform/src/hoist.js
@@ -9,6 +9,7 @@
  */
 
 import * as t from "babel-types";
+import * as util from "./util";
 let hasOwn = Object.prototype.hasOwnProperty;
 
 // The hoist function takes a FunctionExpression or FunctionDeclaration
@@ -57,7 +58,7 @@ exports.hoist = function(funPath) {
         } else {
           // We don't need to traverse this expression any further because
           // there can't be any new declarations inside an expression.
-          path.replaceWith(t.expressionStatement(expr));
+          util.replaceWithOrRemove(path, t.expressionStatement(expr));
         }
 
         // Since the original node has been either removed or replaced,
@@ -69,14 +70,14 @@ exports.hoist = function(funPath) {
     ForStatement: function(path) {
       let init = path.node.init;
       if (t.isVariableDeclaration(init)) {
-        path.get("init").replaceWith(varDeclToExpr(init, false));
+        util.replaceWithOrRemove(path.get("init"), varDeclToExpr(init, false));
       }
     },
 
     ForXStatement: function(path) {
       let left = path.get("left");
       if (left.isVariableDeclaration()) {
-        left.replaceWith(varDeclToExpr(left.node, true));
+        util.replaceWithOrRemove(left, varDeclToExpr(left.node, true));
       }
     },
 
@@ -110,7 +111,7 @@ exports.hoist = function(funPath) {
         // If the parent node is not a block statement, then we can just
         // replace the declaration with the equivalent assignment form
         // without worrying about hoisting it.
-        path.replaceWith(assignment);
+        util.replaceWithOrRemove(path, assignment);
       }
 
       // Don't hoist variables out of inner functions.

--- a/packages/regenerator-transform/src/replaceShorthandObjectMethod.js
+++ b/packages/regenerator-transform/src/replaceShorthandObjectMethod.js
@@ -1,4 +1,5 @@
 import * as t from "babel-types";
+import * as util from "./util";
 
 // this function converts a shorthand object generator method into a normal
 // (non-shorthand) object property which is a generator function expression. for
@@ -56,7 +57,7 @@ export default function replaceShorthandObjectMethod(path) {
     path.node.async
   );
 
-  path.replaceWith(
+  util.replaceWithOrRemove(path,
     t.objectProperty(
       t.cloneDeep(path.node.key), // key
       functionExpression, //value

--- a/packages/regenerator-transform/src/util.js
+++ b/packages/regenerator-transform/src/util.js
@@ -21,3 +21,11 @@ export function runtimeProperty(name) {
 export function isReference(path) {
   return path.isReferenced() || path.parentPath.isAssignmentExpression({ left: path.node });
 }
+
+export function replaceWithOrRemove(path, replacement) {
+  if (replacement) {
+    path.replaceWith(replacement)
+  } else {
+    path.remove();
+  }
+}

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -150,7 +150,7 @@ exports.visitor = {
       }
 
       if (wasGeneratorFunction && t.isExpression(node)) {
-        path.replaceWith(t.callExpression(util.runtimeProperty("mark"), [node]));
+        util.replaceWithOrRemove(path, t.callExpression(util.runtimeProperty("mark"), [node]))
       }
 
       // Generators are processed in 'exit' handlers so that regenerator only has to run on
@@ -253,7 +253,7 @@ let argumentsVisitor = {
 
   Identifier: function(path, state) {
     if (path.node.name === "arguments" && util.isReference(path)) {
-      path.replaceWith(state.argsId);
+      util.replaceWithOrRemove(path, state.argsId);
       state.didRenameArguments = true;
     }
   }
@@ -264,7 +264,7 @@ let functionSentVisitor = {
     let { node } = path;
 
     if (node.meta.name === "function" && node.property.name === "sent") {
-      path.replaceWith(t.memberExpression(this.context, t.identifier("_sent")));
+      util.replaceWithOrRemove(path, t.memberExpression(this.context, t.identifier("_sent")));
     }
   }
 };
@@ -281,7 +281,7 @@ let awaitVisitor = {
     // Transforming `await x` to `yield regeneratorRuntime.awrap(x)`
     // causes the argument to be wrapped in such a way that the runtime
     // can distinguish between awaited and merely yielded values.
-    path.replaceWith(t.yieldExpression(
+    util.replaceWithOrRemove(path, t.yieldExpression(
       t.callExpression(
         util.runtimeProperty("awrap"),
         [argument]

--- a/test/replaceWith-falsy.js
+++ b/test/replaceWith-falsy.js
@@ -1,0 +1,3 @@
+async function foo() {
+  for (let i; i;);
+}

--- a/test/run.js
+++ b/test/run.js
@@ -233,4 +233,28 @@ enqueue("./bin/regenerator", [
   "./test/nothing-to-transform.js"
 ], true);
 
+// Make sure we run the command-line tool on a file that would trigger this error:
+//
+//     You passed `path.replaceWith()` a falsy node, use `path.remove()` instead
+
+enqueue("./bin/regenerator", [
+  "./test/replaceWith-falsy.js"
+], true);
+
+enqueue("./bin/regenerator", [
+  "--include-runtime",
+  "./test/replaceWith-falsy.js"
+], true);
+
+enqueue("./bin/regenerator", [
+  "--disable-async",
+  "./test/replaceWith-falsy.js"
+], true);
+
+enqueue("./bin/regenerator", [
+  "--include-runtime",
+  "--disable-async",
+  "./test/replaceWith-falsy.js"
+], true);
+
 flush();


### PR DESCRIPTION
Before, when regenerator is run with the following input:

```js
async function foo() {
  for (let i; i;);
}
```

it throws this error:

    You passed `path.replaceWith()` a falsy node, use `path.remove()` instead

With this change, the following code is output:

```js
function foo() {
  var i;
  return regeneratorRuntime.async(function foo$(_context) {
    while (1) {
      switch (_context.prev = _context.next) {
        case 0:
          for (; i;) {}

        case 1:
        case "end":
          return _context.stop();
      }
    }
  }, null, this);
}
```

Fixes https://github.com/babel/babel/issues/4953