### PR TITLE
Inject name into plugin

### DIFF
--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -17,6 +17,8 @@ import * as util from "./util";
 
 let getMarkInfo = require("private").makeAccessor();
 
+exports.name = "regenerator-transform";
+
 exports.visitor = {
   Function: {
     exit: function(path, state) {


### PR DESCRIPTION
Babel 7 onward, a name is mandatory to facilitate plugin ordering