### PR TITLE
refactor mark declaration, add __PURE__ comments (#286)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "regenerator-preset": "^0.9.6",
     "regenerator-runtime": "^0.10.5",
     "regenerator-transform": "^0.9.12",
-    "through": "^2.3.8",
-    "uglify-js": "^3.0.27"
+    "through": "^2.3.8"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
@@ -57,7 +56,8 @@
     "lerna": "^2.0.0",
     "mocha": "^2.3.4",
     "promise": "^7.0.4",
-    "semver": "^5.0.3"
+    "semver": "^5.0.3",
+    "uglify-js": "^3.0.27"
   },
   "license": "BSD",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "regenerator-preset": "^0.9.6",
     "regenerator-runtime": "^0.10.5",
     "regenerator-transform": "^0.9.12",
-    "through": "^2.3.8"
+    "through": "^2.3.8",
+    "uglify-js": "^3.0.27"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",

--- a/test/tests.transform.js
+++ b/test/tests.transform.js
@@ -48,56 +48,101 @@ describe("_blockHoist nodes", function() {
   });
 });
 
-describe("marked", function() {
-  it("should work with a single function", function() {
-    var ast = recast.parse('function* foo(){};', {
-        parser: require("babylon")
-    });
-    const code = recast.print(transform(ast)).code;
-    assert.notStrictEqual(
-      code.indexOf(
-        'var _marked = regeneratorRuntime.mark(foo);'
-      ), -1
-    );
-  });
-  it("should work with multiple functions", function() {
-    var ast = recast.parse([
-      'function* foo(){};',
-      'function* bar() {};'
-    ].join("\n"), {
-        parser: require("babylon")
-    });
-    const code = recast.print(transform(ast)).code;
-    assert.notStrictEqual(
-      code.indexOf(
-        'var _marked = regeneratorRuntime.mark(foo), _marked2 = regeneratorRuntime.mark(bar);'
-      ), -1
-    );
-  });
-});
+context("functions", function() {
+  var itMarksCorrectly = function(marked, varName) {
+    // marked should be a VariableDeclarator
+    n.VariableDeclarator.assert(marked);
 
-// TODO - how do i get recast to return comments?
-describe("pure", function() {
-  xit("should work with a function expression", function() {
-    var ast = recast.parse('var a = function* foo(){};', {
-        parser: require("babylon")
+    // using our variable name
+    assert.strictEqual(marked.id.name, varName);
+
+    // assiging a call expression to regeneratorRuntime.mark()
+    n.CallExpression.assert(marked.init);
+    assert.strictEqual(marked.init.callee.object.name, 'regeneratorRuntime')
+    assert.strictEqual(marked.init.callee.property.name, 'mark')
+
+    // with said call expression marked as a pure function
+    assert.strictEqual(marked.init.leadingComments[0].value, '#__PURE__');
+  };
+
+  describe("function declarations", function() {
+    it("should work with a single function", function() {
+      var ast = recast.parse('function* foo(){};', {
+          parser: require("babylon")
+      });
+
+      // get our declarations
+      const declaration = transform(ast).program.body[0];
+      n.VariableDeclaration.assert(declaration);
+      const declarations = declaration.declarations;
+
+      // verify our declaration is marked correctly
+      itMarksCorrectly(declarations[0], '_marked');
+
+      // and has our function name as its first argument
+      assert.strictEqual(declarations[0].init.arguments[0].name, 'foo');
     });
-    const code = recast.print(transform(ast)).code;
-    assert.notStrictEqual(
-      code.indexOf(
-        'var a = /*#__PURE__*/regeneratorRuntime.mark(function foo() {'
-      ), -1
-    );
+
+    it("should work with multiple functions", function() {
+      var ast = recast.parse([
+        'function* foo(){};',
+        'function* bar() {};'
+      ].join("\n"), {
+          parser: require("babylon")
+      });
+
+      // get our declarations
+      const declaration = transform(ast).program.body[0];
+      n.VariableDeclaration.assert(declaration);
+      const declarations = declaration.declarations;
+
+      // verify our declarations are marked correctly and have our function name
+      // as their first argument
+      itMarksCorrectly(declarations[0], '_marked');
+      n.Identifier.assert(declarations[0].init.arguments[0]);
+      assert.strictEqual(declarations[0].init.arguments[0].name, 'foo');
+
+      itMarksCorrectly(declarations[1], '_marked2');
+      n.Identifier.assert(declarations[1].init.arguments[0]);
+      assert.strictEqual(declarations[1].init.arguments[0].name, 'bar');
+    });
   });
-  xit("should work with a function declaration", function() {
-    var ast = recast.parse('function* foo(){};', {
-      parser: require("babylon")
+
+  describe("function expressions", function() {
+    it("should work with a named function", function() {
+      var ast = recast.parse('var a = function* foo(){};', {
+          parser: require("babylon")
+      });
+
+      // get our declarations
+      const declaration = transform(ast).program.body[0];
+      n.VariableDeclaration.assert(declaration);
+      const declarator = declaration.declarations[0];
+
+      // verify our declaration is marked correctly
+      itMarksCorrectly(declarator, 'a');
+
+      // and that our first argument is our original function expression
+      n.FunctionExpression.assert(declarator.init.arguments[0]);
+      assert.strictEqual(declarator.init.arguments[0].id.name, 'foo');
     });
-    const code = recast.print(transform(ast)).code;
-    assert.notStrictEqual(
-      code.indexOf(
-        'var a = /*#__PURE__*/Object.defineProperty( /*#__PURE__*/regeneratorRuntime.mark'
-      ), -1
-    );
+
+    it("should work with an anonymous function", function() {
+      var ast = recast.parse('var a = function* (){};', {
+          parser: require("babylon")
+      });
+
+      // get our declarations
+      const declaration = transform(ast).program.body[0];
+      n.VariableDeclaration.assert(declaration);
+      const declarator = declaration.declarations[0];
+
+      // verify our declaration is marked correctly
+      itMarksCorrectly(declarator, 'a');
+
+      // and that our first argument is our original function expression
+      n.FunctionExpression.assert(declarator.init.arguments[0]);
+      assert.strictEqual(declarator.init.arguments[0].id.name, '_callee');
+    });
   });
 });

--- a/test/tests.transform.js
+++ b/test/tests.transform.js
@@ -47,3 +47,57 @@ describe("_blockHoist nodes", function() {
     assert.deepEqual(names, ["hoistMe", "doNotHoistMe", "oyez"]);
   });
 });
+
+describe("marked", function() {
+  it("should work with a single function", function() {
+    var ast = recast.parse('function* foo(){};', {
+        parser: require("babylon")
+    });
+    const code = recast.print(transform(ast)).code;
+    assert.notStrictEqual(
+      code.indexOf(
+        'var _marked = regeneratorRuntime.mark(foo);'
+      ), -1
+    );
+  });
+  it("should work with multiple functions", function() {
+    var ast = recast.parse([
+      'function* foo(){};',
+      'function* bar() {};'
+    ].join("\n"), {
+        parser: require("babylon")
+    });
+    const code = recast.print(transform(ast)).code;
+    assert.notStrictEqual(
+      code.indexOf(
+        'var _marked = regeneratorRuntime.mark(foo), _marked2 = regeneratorRuntime.mark(bar);'
+      ), -1
+    );
+  });
+});
+
+// TODO - how do i get recast to return comments?
+describe("pure", function() {
+  xit("should work with a function expression", function() {
+    var ast = recast.parse('var a = function* foo(){};', {
+        parser: require("babylon")
+    });
+    const code = recast.print(transform(ast)).code;
+    assert.notStrictEqual(
+      code.indexOf(
+        'var a = /*#__PURE__*/regeneratorRuntime.mark(function foo() {'
+      ), -1
+    );
+  });
+  xit("should work with a function declaration", function() {
+    var ast = recast.parse('function* foo(){};', {
+      parser: require("babylon")
+    });
+    const code = recast.print(transform(ast)).code;
+    assert.notStrictEqual(
+      code.indexOf(
+        'var a = /*#__PURE__*/Object.defineProperty( /*#__PURE__*/regeneratorRuntime.mark'
+      ), -1
+    );
+  });
+});

--- a/test/tests.transform.js
+++ b/test/tests.transform.js
@@ -76,7 +76,7 @@ describe("uglifyjs dead code removal", function() {
       parser: require("babylon")
     });
   }
-  
+
   it("works with function expressions", function() {
     var file1 = compile([
       'var foo = function* () {};',
@@ -98,7 +98,7 @@ describe("uglifyjs dead code removal", function() {
     assert.strictEqual(declaration.id.name, 'foo');
   });
 
-  it("works with function definitions", function() {
+  it("works with function declarations", function() {
     var file1 = compile([
       'function* foo() {};',
       'function* bar() {};'
@@ -134,7 +134,7 @@ describe("uglifyjs dead code removal", function() {
 })
 
 context("functions", function() {
-  var itMarksCorrectly = function(marked, varName) {
+  function marksCorrectly(marked, varName) {
     // marked should be a VariableDeclarator
     n.VariableDeclarator.assert(marked);
 
@@ -148,12 +148,12 @@ context("functions", function() {
 
     // with said call expression marked as a pure function
     assert.strictEqual(marked.init.leadingComments[0].value, '#__PURE__');
-  };
+  }
 
   describe("function declarations", function() {
     it("should work with a single function", function() {
       var ast = recast.parse('function* foo(){};', {
-          parser: require("babylon")
+        parser: require("babylon")
       });
 
       // get our declarations
@@ -162,7 +162,7 @@ context("functions", function() {
       const declarations = declaration.declarations;
 
       // verify our declaration is marked correctly
-      itMarksCorrectly(declarations[0], '_marked');
+      marksCorrectly(declarations[0], '_marked');
 
       // and has our function name as its first argument
       assert.strictEqual(declarations[0].init.arguments[0].name, 'foo');
@@ -173,7 +173,7 @@ context("functions", function() {
         'function* foo() {};',
         'function* bar() {};'
       ].join("\n"), {
-          parser: require("babylon")
+        parser: require("babylon")
       });
 
       // get our declarations
@@ -183,11 +183,11 @@ context("functions", function() {
 
       // verify our declarations are marked correctly and have our function name
       // as their first argument
-      itMarksCorrectly(declarations[0], '_marked');
+      marksCorrectly(declarations[0], '_marked');
       n.Identifier.assert(declarations[0].init.arguments[0]);
       assert.strictEqual(declarations[0].init.arguments[0].name, 'foo');
 
-      itMarksCorrectly(declarations[1], '_marked2');
+      marksCorrectly(declarations[1], '_marked2');
       n.Identifier.assert(declarations[1].init.arguments[0]);
       assert.strictEqual(declarations[1].init.arguments[0].name, 'bar');
     });
@@ -196,7 +196,7 @@ context("functions", function() {
   describe("function expressions", function() {
     it("should work with a named function", function() {
       var ast = recast.parse('var a = function* foo(){};', {
-          parser: require("babylon")
+        parser: require("babylon")
       });
 
       // get our declarations
@@ -205,7 +205,7 @@ context("functions", function() {
       const declarator = declaration.declarations[0];
 
       // verify our declaration is marked correctly
-      itMarksCorrectly(declarator, 'a');
+      marksCorrectly(declarator, 'a');
 
       // and that our first argument is our original function expression
       n.FunctionExpression.assert(declarator.init.arguments[0]);
@@ -214,7 +214,7 @@ context("functions", function() {
 
     it("should work with an anonymous function", function() {
       var ast = recast.parse('var a = function* (){};', {
-          parser: require("babylon")
+        parser: require("babylon")
       });
 
       // get our declarations
@@ -223,7 +223,7 @@ context("functions", function() {
       const declarator = declaration.declarations[0];
 
       // verify our declaration is marked correctly
-      itMarksCorrectly(declarator, 'a');
+      marksCorrectly(declarator, 'a');
 
       // and that our first argument is our original function expression
       n.FunctionExpression.assert(declarator.init.arguments[0]);


### PR DESCRIPTION
(see also #301 for old discussion)

with the current code, this:
```
export function* test() {}
export function* abc() {}
```
compiles to this:
```
var _marked = [test, abc].map(regeneratorRuntime.mark);

export function test() {
  return regeneratorRuntime.wrap(function test$(_context) {
    while (1) {
      switch (_context.prev = _context.next) {
        case 0:
        case "end":
          return _context.stop();
      }
    }
  }, _marked[0], this);
}

export function abc() {
  return regeneratorRuntime.wrap(function abc$(_context2) {
    while (1) {
      switch (_context2.prev = _context2.next) {
        case 0:
        case "end":
          return _context2.stop();
      }
    }
  }, _marked[1], this);
}
```
because of the `[test, abc].map` call `uglifyjs` won't strip out `test` or `abc` if they're never actually imported (`webpack` does correctly identify them as non-imported though). 

this pr changes two things:
1. the `map` call is unrolled and each call to `regeneratorRuntime.mark` has the magic `#__PURE__` comment added to it so that uglify knows it can drop the code:
```
var _marked = /*#__PURE__*/regeneratorRuntime.mark(test),
    _marked2 = /*#__PURE__*/regeneratorRuntime.mark(abc);
export function test() {
  return regeneratorRuntime.wrap(function test$(_context) {
    while (1) {
      switch (_context.prev = _context.next) {
        case 0:
        case "end":
          return _context.stop();
      }
    }
  }, _marked, this);
}
export function abc() {
  return regeneratorRuntime.wrap(function abc$(_context2) {
    while (1) {
      switch (_context2.prev = _context2.next) {
        case 0:
        case "end":
          return _context2.stop();
      }
    }
  }, _marked2, this);
}
```
2. the magic comment is also added to function expressions, so this:
```
var foo = function* (){}
```
is compiled to this:
```
var foo = /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
  return regeneratorRuntime.wrap(function _callee$(_context) {
    while (1) {
      switch (_context.prev = _context.next) {
        case 0:
        case "end":
          return _context.stop();
      }
    }
  }, _callee, this);
});
```

i added tests to verify the new variable declaration scheme. i haven't been able to get `recast` to return comments to me in a test though - i've verified that this works via `bin/regenerator` (to verify the comments are there) and by using it in my project with `uglifyjs` and verifying that unused generators are being stripped out. 