### PR TITLE
Only export plugin name for Babel>=7.x

### DIFF
--- a/packages/regenerator-transform/src/index.js
+++ b/packages/regenerator-transform/src/index.js
@@ -8,6 +8,21 @@
  * the same directory.
  */
 
-export default function () {
-  return require("./visit");
+export default function (context) {
+  const plugin = {
+    visitor: require("./visit").visitor,
+  };
+
+  // Some presets manually call child presets, but fail to pass along the
+  // context object. Out of an abundance of caution, we verify that it
+  // exists first to avoid causing unnecessary breaking changes.
+  const version = context && context.version;
+
+  // The "name" property is not allowed in older version of Babel 6.x and
+  // will cause it to throw an exception.
+  if (version && !/^6\./.test(version)) {
+    plugin.name = "regenerator-transform";
+  }
+
+  return plugin;
 }

--- a/packages/regenerator-transform/src/index.js
+++ b/packages/regenerator-transform/src/index.js
@@ -20,7 +20,7 @@ export default function (context) {
 
   // The "name" property is not allowed in older versions of Babel (6.x)
   // and will cause the plugin validator to throw an exception.
-  if (version && parseInt(version) >= 7) {
+  if (version && parseInt(version, 10) >= 7) {
     plugin.name = "regenerator-transform";
   }
 

--- a/packages/regenerator-transform/src/index.js
+++ b/packages/regenerator-transform/src/index.js
@@ -18,9 +18,9 @@ export default function (context) {
   // exists first to avoid causing unnecessary breaking changes.
   const version = context && context.version;
 
-  // The "name" property is not allowed in older version of Babel 6.x and
-  // will cause it to throw an exception.
-  if (version && !/^6\./.test(version)) {
+  // The "name" property is not allowed in older versions of Babel (6.x)
+  // and will cause the plugin validator to throw an exception.
+  if (version && parseInt(version) >= 7) {
     plugin.name = "regenerator-transform";
   }
 

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -17,8 +17,6 @@ import { Emitter } from "./emit";
 import replaceShorthandObjectMethod from "./replaceShorthandObjectMethod";
 import * as util from "./util";
 
-exports.name = "regenerator-transform";
-
 exports.visitor = {
   Function: {
     exit: function(path, state) {


### PR DESCRIPTION
Alternate approach for https://github.com/facebook/regenerator/pull/311 that will avoid breaking changes for Babel 6.x