### PR TITLE
Don't error if Gp[toStringTagSymbol] is read-only

### DIFF
--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -410,7 +410,9 @@
   // unified ._invoke helper method.
   defineIteratorMethods(Gp);
 
-  Gp[toStringTagSymbol] = "Generator";
+  try {
+    Gp[toStringTagSymbol] = "Generator";
+  } finally {}
 
   // A Generator should always return itself as the iterator object when the
   // @@iterator function is called on it. Some browsers' implementations of the


### PR DESCRIPTION
I'm not so sure that this will be merged. I've noticed that if using https://polyfill.io with this project that this line throws an error because the IteratorPrototype[Symbol.toString] is read-only