### PR TITLE
Use plugin-provided context.types instead of importing babel-types.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
 
 language: node_js
 node_js:
+  - "9"
   - "8"
   - "7"
   - "6"

--- a/packages/regenerator-transform/package.json
+++ b/packages/regenerator-transform/package.json
@@ -29,7 +29,6 @@
     ]
   },
   "dependencies": {
-    "babel-types": "7.0.0-beta.3",
     "private": "^0.1.6"
   },
   "devDependencies": {

--- a/packages/regenerator-transform/src/hoist.js
+++ b/packages/regenerator-transform/src/hoist.js
@@ -8,7 +8,6 @@
  * the same directory.
  */
 
-import * as t from "babel-types";
 import * as util from "./util";
 let hasOwn = Object.prototype.hasOwnProperty;
 
@@ -17,6 +16,7 @@ let hasOwn = Object.prototype.hasOwnProperty;
 // returns a VariableDeclaration containing just the names of the removed
 // declarations.
 exports.hoist = function(funPath) {
+  const t = util.getTypes();
   t.assertFunction(funPath.node);
 
   let vars = {};

--- a/packages/regenerator-transform/src/index.js
+++ b/packages/regenerator-transform/src/index.js
@@ -10,7 +10,7 @@
 
 export default function (context) {
   const plugin = {
-    visitor: require("./visit").visitor,
+    visitor: require("./visit").getVisitor(context),
   };
 
   // Some presets manually call child presets, but fail to pass along the

--- a/packages/regenerator-transform/src/leap.js
+++ b/packages/regenerator-transform/src/leap.js
@@ -9,8 +9,8 @@
  */
 
 import assert from "assert";
-import * as t from "babel-types";
 import { inherits } from "util";
+import { getTypes } from "./util.js";
 
 function Entry() {
   assert.ok(this instanceof Entry);
@@ -18,7 +18,7 @@ function Entry() {
 
 function FunctionEntry(returnLoc) {
   Entry.call(this);
-  t.assertLiteral(returnLoc);
+  getTypes().assertLiteral(returnLoc);
   this.returnLoc = returnLoc;
 }
 
@@ -27,6 +27,8 @@ exports.FunctionEntry = FunctionEntry;
 
 function LoopEntry(breakLoc, continueLoc, label) {
   Entry.call(this);
+
+  const t = getTypes();
 
   t.assertLiteral(breakLoc);
   t.assertLiteral(continueLoc);
@@ -47,7 +49,7 @@ exports.LoopEntry = LoopEntry;
 
 function SwitchEntry(breakLoc) {
   Entry.call(this);
-  t.assertLiteral(breakLoc);
+  getTypes().assertLiteral(breakLoc);
   this.breakLoc = breakLoc;
 }
 
@@ -57,6 +59,7 @@ exports.SwitchEntry = SwitchEntry;
 function TryEntry(firstLoc, catchEntry, finallyEntry) {
   Entry.call(this);
 
+  const t = getTypes();
   t.assertLiteral(firstLoc);
 
   if (catchEntry) {
@@ -85,6 +88,8 @@ exports.TryEntry = TryEntry;
 function CatchEntry(firstLoc, paramId) {
   Entry.call(this);
 
+  const t = getTypes();
+
   t.assertLiteral(firstLoc);
   t.assertIdentifier(paramId);
 
@@ -97,6 +102,7 @@ exports.CatchEntry = CatchEntry;
 
 function FinallyEntry(firstLoc, afterLoc) {
   Entry.call(this);
+  const t = getTypes();
   t.assertLiteral(firstLoc);
   t.assertLiteral(afterLoc);
   this.firstLoc = firstLoc;
@@ -108,6 +114,8 @@ exports.FinallyEntry = FinallyEntry;
 
 function LabeledEntry(breakLoc, label) {
   Entry.call(this);
+
+  const t = getTypes();
 
   t.assertLiteral(breakLoc);
   t.assertIdentifier(label);

--- a/packages/regenerator-transform/src/meta.js
+++ b/packages/regenerator-transform/src/meta.js
@@ -9,12 +9,13 @@
  */
 
 import assert from "assert";
+import { getTypes } from "./util.js";
 let m = require("private").makeAccessor();
-import * as t from "babel-types";
 let hasOwn = Object.prototype.hasOwnProperty;
 
 function makePredicate(propertyName, knownTypes) {
   function onlyChildren(node) {
+    const t = getTypes();
     t.assertNode(node);
 
     // Assume no side effects until we find out otherwise.
@@ -45,7 +46,7 @@ function makePredicate(propertyName, knownTypes) {
   }
 
   function predicate(node) {
-    t.assertNode(node);
+    getTypes().assertNode(node);
 
     let meta = m(node);
     if (hasOwn.call(meta, propertyName))

--- a/packages/regenerator-transform/src/replaceShorthandObjectMethod.js
+++ b/packages/regenerator-transform/src/replaceShorthandObjectMethod.js
@@ -1,4 +1,3 @@
-import * as t from "babel-types";
 import * as util from "./util";
 
 // this function converts a shorthand object generator method into a normal
@@ -30,6 +29,8 @@ import * as util from "./util";
 // If this function is called with an AST node path that is not a Function (or with an
 // argument that isn't an AST node path), it will throw an error.
 export default function replaceShorthandObjectMethod(path) {
+  const t = util.getTypes();
+
   if (!path.node || !t.isFunction(path.node)) {
     throw new Error("replaceShorthandObjectMethod can only be called on Function AST node paths.");
   }

--- a/packages/regenerator-transform/src/util.js
+++ b/packages/regenerator-transform/src/util.js
@@ -8,9 +8,26 @@
  * the same directory.
  */
 
-import * as t from "babel-types";
+let currentTypes = null;
+
+export function wrapWithTypes(types, fn) {
+  return function (...args) {
+    const oldTypes = currentTypes;
+    currentTypes = types;
+    try {
+      return fn.apply(this, args);
+    } finally {
+      currentTypes = oldTypes;
+    }
+  };
+}
+
+export function getTypes() {
+  return currentTypes;
+}
 
 export function runtimeProperty(name) {
+  const t = getTypes();
   return t.memberExpression(
     t.identifier("regeneratorRuntime"),
     t.identifier(name),


### PR DESCRIPTION
Fixes #328.

cc @hzoo @loganfsmyth 

Instead of passing the `context.types` object throughout `regenerator-transform` (really invasive), or wrapping every module with some sort of constructor function (which would require abandoning both `require` and `import`), I decided to use stack-based local state in the `util.js` module, so that `currentTypes` can be retrieved from anywhere, as long as there's a function wrapped with `util.wrapWithTypes` currently on the stack. Since `regenerator-transform` is entirely synchronous, this turns out to be an easy property to enforce, with only one call to `util.wrapWithTypes`.