### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,9 @@ here. Facebook employees who contribute to Regenerator are expected to do
 so in the same way as everyone else. In other words, this document applies
 equally to all contributors.
 
+### Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ### `master` is unsafe
 
 We will do our best to keep `master` in good shape, with tests passing at


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the regenerator community profile](https://github.com/facebook/regenerator/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1324" alt="screen shot 2017-11-26 at 2 09 42 pm" src="https://user-images.githubusercontent.com/1114467/33244856-9cfbb3b2-d2b3-11e7-8cb5-adc22bdf29c1.png">
<img width="1322" alt="screen shot 2017-11-26 at 2 09 49 pm" src="https://user-images.githubusercontent.com/1114467/33244857-9d16eed4-d2b3-11e7-99d7-f7437313638a.png">

**issue:**
internal task t23481323