### PR TITLE
fix: fix isGeneratorFunction bugs in IE 10

### DIFF
--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -131,9 +131,12 @@
 
   runtime.mark = function(genFun) {
     if (Object.setPrototypeOf) {
+    // NOT IE
       Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
     } else {
+      // IE
       genFun.__proto__ = GeneratorFunctionPrototype;
+      genFun.constructor.displayName = 'GeneratorFunction'; // fix isGeneratorFunction in IE 10
       if (!(toStringTagSymbol in genFun)) {
         genFun[toStringTagSymbol] = "GeneratorFunction";
       }


### PR DESCRIPTION
function `isGeneratorFunction`  doesn't work properly in IE 10，so I add a line code to fix it. 