### PR TITLE
Preserve the location of the replaced 'yield' nodes.

### DIFF
--- a/packages/regenerator-transform/src/emit.js
+++ b/packages/regenerator-transform/src/emit.js
@@ -1172,21 +1172,29 @@ Ep.explodeExpression = function(path, ignoreResult) {
     if (arg && expr.delegate) {
       let result = self.makeTempVar();
 
-      self.emit(t.returnStatement(t.callExpression(
-        self.contextProperty("delegateYield"), [
+      let ret = t.returnStatement(t.callExpression(
+        self.contextProperty("delegateYield"),
+        [
           arg,
           t.stringLiteral(result.property.name),
           after
         ]
-      )));
+      ));
+      ret.loc = expr.loc;
 
+      self.emit(ret);
       self.mark(after);
 
       return result;
     }
 
     self.emitAssign(self.contextProperty("next"), after);
-    self.emit(t.returnStatement(arg || null));
+
+    let ret = t.returnStatement(arg || null);
+    // Preserve the `yield` location so that source mappings for the statements
+    // link back to the yield properly.
+    ret.loc = expr.loc;
+    self.emit(ret);
     self.mark(after);
 
     return self.contextProperty("sent");


### PR DESCRIPTION
Fixes #342 
Refs https://github.com/devtools-html/debugger.html/issues/5561, https://github.com/devtools-html/debugger.html/issues/6400

It doesn't look like there are any tests that validate the source mappings, but if you feel strongly about it I'd be happy to explore adding some.

Like I mentioned in #342, stuff like https://github.com/facebook/regenerator/blob/58c0eca04145da79c263194a605ca5a6294a72b4/packages/regenerator-transform/src/emit.js#L1162 also loses the location because it replaces the nodes with fresh ones that don't have a location, but I'm leaving that for now since it's a more aggressive change.