### PR TITLE
Await yielded promises in async generator functions.

### DIFF
--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -168,22 +168,14 @@
         return Promise.resolve(value).then(function(unwrapped) {
           // When a yielded Promise is resolved, its final value becomes
           // the .value of the Promise<{value,done}> result for the
-          // current iteration. If the Promise is rejected, however, the
-          // result for this iteration will be rejected with the same
-          // reason. Note that rejections of yielded Promises are not
-          // thrown back into the generator function, as is the case
-          // when an awaited Promise is rejected. This difference in
-          // behavior between yield and await is important, because it
-          // allows the consumer to decide what to do with the yielded
-          // rejection (swallow it and continue, manually .throw it back
-          // into the generator, abandon iteration, whatever). With
-          // await, by contrast, there is no opportunity to examine the
-          // rejection reason outside the generator function, so the
-          // only option is to throw it from the await expression, and
-          // let the generator function handle the exception.
+          // current iteration.
           result.value = unwrapped;
           resolve(result);
-        }, reject);
+        }, function(error) {
+          // If a rejected Promise was yielded, throw the rejection back
+          // into the async generator function so it can be handled there.
+          return invoke("throw", error, resolve, reject);
+        });
       }
     }
 

--- a/test/async.js
+++ b/test/async.js
@@ -463,21 +463,26 @@ describe("async generator functions", function() {
     var returned = new Error("returned rejection");
 
     async function *gen() {
-      assert.strictEqual(yield Promise.reject(yielded), "first sent");
-      assert.strictEqual(yield "middle", "second sent");
-      return Promise.reject(returned);
+      assert.strictEqual(yield "first yielded", "first sent");
+      try {
+        assert.strictEqual(yield Promise.reject(yielded), "not reached");
+      } catch (e) {
+        assert.strictEqual(yield e, "second sent");
+        return Promise.reject(returned);
+      }
     }
 
     var iter = gen();
 
     return iter.next().then(function(result) {
-      assert.ok(false, "should have yielded a rejected Promise");
-    }, function(error) {
-      assert.strictEqual(error, yielded);
-      return iter.next("first sent");
-    }).then(function(result) {
       assert.deepEqual(result, {
-        value: "middle",
+        value: "first yielded",
+        done: false
+      });
+      return iter.next("first sent");
+    }).then(function (result) {
+      assert.deepEqual(result, {
+        value: yielded,
         done: false
       });
       return iter.next("second sent");

--- a/test/run.js
+++ b/test/run.js
@@ -106,6 +106,15 @@ if (semver.gte(process.version, "0.11.2")) {
   ]);
 }
 
+if (semver.gte(process.version, "8.10.0")) {
+  enqueue("mocha", [
+    "--harmony",
+    "--reporter", "spec",
+    "--require", "./test/runtime.js",
+    "./test/async.js",
+  ]);
+}
+
 if (semver.gte(process.version, "4.0.0")) {
   enqueue("mocha", [
     "--harmony",


### PR DESCRIPTION
I noticed this bug after realizing that we were not running the `test/async.js` tests natively in any version of Node. After enabling the native async tests, there was one test that failed in native Node, and it was a test that exercised yielding a rejected `Promise` in an async generator function.

In an async generator function,
```js   
yield <promise>
```    
should have the semantics of
```js   
yield await <promise>
```    
per [TC39 consensus](https://github.com/tc39/tc39-notes/blob/master/es8/2017-05/may-25.md#15iva-revisiting-async-generator-yield-behavior). In other words, if `<promise>` is rejected, that rejection should be thrown back into the async generator function, rather than being exposed as a normal value to the consumer of the function (as this code was previously careful to do). As you can see from the comments I deleted, this new (more spec-compliant) behavior needs a bit less explanation, which is always nice. Even better, the only changes I needed to make were in `regenerator-runtime`, so existing compiled code will not need to be recompiled.