### PR TITLE
Replace "require" with "import" in regenerator-transform source

### DIFF
--- a/packages/regenerator-transform/src/index.js
+++ b/packages/regenerator-transform/src/index.js
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { getVisitor } from "./visit";
+
 export default function (context) {
   const plugin = {
-    visitor: require("./visit").getVisitor(context),
+    visitor: getVisitor(context),
   };
 
   // Some presets manually call child presets, but fail to pass along the

--- a/packages/regenerator-transform/src/leap.js
+++ b/packages/regenerator-transform/src/leap.js
@@ -6,8 +6,9 @@
  */
 
 import assert from "assert";
+import { Emitter } from "./emit";
 import { inherits } from "util";
-import { getTypes } from "./util.js";
+import { getTypes } from "./util";
 
 function Entry() {
   assert.ok(this instanceof Entry);
@@ -127,7 +128,6 @@ exports.LabeledEntry = LabeledEntry;
 function LeapManager(emitter) {
   assert.ok(this instanceof LeapManager);
 
-  let Emitter = require("./emit").Emitter;
   assert.ok(emitter instanceof Emitter);
 
   this.emitter = emitter;

--- a/packages/regenerator-transform/src/meta.js
+++ b/packages/regenerator-transform/src/meta.js
@@ -7,7 +7,9 @@
 
 import assert from "assert";
 import { getTypes } from "./util.js";
-let m = require("private").makeAccessor();
+import { makeAccessor } from "private";
+
+let m = makeAccessor();
 let hasOwn = Object.prototype.hasOwnProperty;
 
 function makePredicate(propertyName, knownTypes) {

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -12,6 +12,7 @@ import { hoist } from "./hoist";
 import { Emitter } from "./emit";
 import replaceShorthandObjectMethod from "./replaceShorthandObjectMethod";
 import * as util from "./util";
+import { makeAccessor } from "private";
 
 exports.getVisitor = ({ types: t }) => ({
   Function: {
@@ -194,7 +195,7 @@ function getOuterFnExpr(funPath) {
   return t.clone(node.id);
 }
 
-const getMarkInfo = require("private").makeAccessor();
+const getMarkInfo = makeAccessor();
 
 function getMarkedFunctionId(funPath) {
   const t = util.getTypes();


### PR DESCRIPTION
I think @cito125 (`mad_babeler` on BabelJS Slack) has already been in contact with you about some issues we're having using `regenerator-transform` together with Babel 7, React Native and `proxyquire`. Turns out that replacing the `require` statements in the source with ES module `import` statements solves our issue, as we no longer end up importing the `emit.js` source twice (which causes issues with the type assertion on line 131 of `leap.js`.

Hopefully this is a pretty non-controversial change to update all the `require` statements in the package with `import`s instead!