### PR TITLE
Don't capture "this" when not needed

### DIFF
--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -90,8 +90,14 @@ exports.getVisitor = ({ types: t }) => ({
       // declarations with equivalent assignment expressions.
       let vars = hoist(path);
 
-      let didRenameArguments = renameArguments(path, () => t.clone(argsId));
-      if (didRenameArguments) {
+      let context = {
+        usesThis: false,
+        usesArguments: false,
+        getArgsId: () => t.clone(argsId),
+      };
+      path.traverse(argumentsThisVisitor, context);
+
+      if (context.usesArguments) {
         vars = vars || t.variableDeclaration("var", []);
         const argumentIdentifier = t.identifier("arguments");
         // we need to do this as otherwise arguments in arrow functions gets hoisted
@@ -108,16 +114,22 @@ exports.getVisitor = ({ types: t }) => ({
         outerBody.push(vars);
       }
 
-      let wrapArgs = [
-        emitter.getContextFunction(innerFnId),
+      let wrapArgs = [emitter.getContextFunction(innerFnId)];
+      let tryLocsList = emitter.getTryLocsList();
+
+      if (node.generator) {
+        wrapArgs.push(outerFnExpr);
+      } else if (context.usesThis || tryLocsList) {
         // Async functions that are not generators don't care about the
         // outer function because they don't need it to be marked and don't
         // inherit from its .prototype.
-        node.generator ? outerFnExpr : t.nullLiteral(),
-        t.thisExpression()
-      ];
-
-      let tryLocsList = emitter.getTryLocsList();
+        wrapArgs.push(t.nullLiteral());
+      }
+      if (context.usesThis) {
+        wrapArgs.push(t.thisExpression());
+      } else if (tryLocsList) {
+        wrapArgs.push(t.nullLiteral());
+      }
       if (tryLocsList) {
         wrapArgs.push(tryLocsList);
       }
@@ -243,22 +255,7 @@ function getMarkedFunctionId(funPath) {
   return t.clone(markedId);
 }
 
-function renameArguments(funcPath, getArgsId) {
-  let state = {
-    didRenameArguments: false,
-    getArgsId: getArgsId
-  };
-
-  funcPath.traverse(argumentsVisitor, state);
-
-  // If the traversal replaced any arguments references, then we need to
-  // alias the outer function's arguments binding (be it the implicit
-  // arguments object or some other parameter or variable) to the variable
-  // named by argsId.
-  return state.didRenameArguments;
-}
-
-let argumentsVisitor = {
+let argumentsThisVisitor = {
   "FunctionExpression|FunctionDeclaration": function(path) {
     path.skip();
   },
@@ -266,8 +263,12 @@ let argumentsVisitor = {
   Identifier: function(path, state) {
     if (path.node.name === "arguments" && util.isReference(path)) {
       util.replaceWithOrRemove(path, state.getArgsId());
-      state.didRenameArguments = true;
+      state.usesArguments = true;
     }
+  },
+
+  ThisExpression: function(path, state) {
+    state.usesThis = true;
   }
 };
 
@@ -311,4 +312,14 @@ let awaitVisitor = {
       false
     ));
   }
+};
+
+let thisVisitor = {
+  "FunctionExpression|FunctionDeclaration|Class": function(path) {
+    path.skip(); // Different this context
+  },
+  ThisExpression: function(path, state) {
+    state.referencesThis = true;
+    path.stop();
+  },
 };

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -313,13 +313,3 @@ let awaitVisitor = {
     ));
   }
 };
-
-let thisVisitor = {
-  "FunctionExpression|FunctionDeclaration|Class": function(path) {
-    path.skip(); // Different this context
-  },
-  ThisExpression: function(path, state) {
-    state.referencesThis = true;
-    path.stop();
-  },
-};

--- a/test/async.js
+++ b/test/async.js
@@ -251,6 +251,44 @@ describe("async functions and await expressions", function() {
       }).catch(done);
     });
   });
+
+  describe("the this object", function () {
+    it("should default to undefined (strict)", function (done) {
+      async function f() {
+        "use strict";
+  
+        return this;
+      }
+  
+      f().then(function(value) {
+        assert.strictEqual(value, undefined);
+        done();
+      }).catch(done);
+    });
+  
+    it("should respect .call's this", function (done) {
+      async function f() {
+        return this;
+      }
+  
+      var self = {};
+      f.call(self).then(function(value) {
+        assert.strictEqual(value, self);
+        done();
+      }).catch(done);
+    });
+  
+    it("shouldn't capture this when not needed", function () {
+      // https://github.com/babel/babel/issues/4056
+  
+      async function f() {
+        return 0;
+      }
+  
+      var source = String(f);
+      assert.strictEqual(source.indexOf("this"), -1);
+    });
+  });
 });
 
 describe("async generator functions", function() {

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -1711,6 +1711,44 @@ describe("the arguments object", function() {
   });
 });
 
+describe("the this object", function () {
+  it("should default to undefined (strict)", function () {
+    function *gen() {
+      "use strict";
+
+      yield this;
+      return this;
+    }
+
+    var it = gen();
+    assert.strictEqual(it.next().value, undefined);
+    assert.strictEqual(it.next().value, undefined);
+  });
+
+  it("should respect .call's this", function () {
+    function *gen() {
+      yield this;
+      return this;
+    }
+
+    var self = {};
+    var it = gen.call(self);
+    assert.strictEqual(it.next().value, self);
+    assert.strictEqual(it.next().value, self);
+  });
+
+  it("shouldn't capture this when not needed", function () {
+    // https://github.com/babel/babel/issues/4056
+
+    function *gen() {
+      return 0;
+    }
+
+    var source = String(gen);
+    assert.strictEqual(source.indexOf("this"), -1);
+  });
+});
+
 describe("directive strings", function () {
   function *strict() {
     "use strict";


### PR DESCRIPTION
Fixes babel/babel#4056

As explained in that issue, regenerator prevents engines from collectiong `this` even when it is not used, causing a memory leak.

Input:
```js
function f() {
  return async _ => {};
}

function g() {
  return async _ => this;
}
```

<details>
<summary>Output before this PR:</summary>

```js
function f() {
  return _ => {
    return regeneratorRuntime.async(function _callee$(_context) {
      while (1) switch (_context.prev = _context.next) {
        case 0:
        case "end":
          return _context.stop();
      }
    }, null, this);
  };
}

function g() {
  return _ => {
    return regeneratorRuntime.async(function _callee2$(_context2) {
      while (1) switch (_context2.prev = _context2.next) {
        case 0:
          return _context2.abrupt("return", this);

        case 1:
        case "end":
          return _context2.stop();
      }
    }, null, this);
  };
}
```
</details>

<details>
<summary>Output after this PR:</summary>

```js
function f() {
  return _ => {
    return regeneratorRuntime.async(function _callee$(_context) {
      while (1) switch (_context.prev = _context.next) {
        case 0:
        case "end":
          return _context.stop();
      }
    }); // <-- difference here!
  };
}

function g() {
  return _ => {
    return regeneratorRuntime.async(function _callee2$(_context2) {
      while (1) switch (_context2.prev = _context2.next) {
        case 0:
          return _context2.abrupt("return", this);

        case 1:
        case "end":
          return _context2.stop();
      }
    }, null, this);
  };
}
```
</details>