### PR TITLE
Remove old bindings when hoisting vars

### DIFF
--- a/test/tests.transform.js
+++ b/test/tests.transform.js
@@ -237,4 +237,20 @@ context("functions", function() {
       assert.strictEqual(declarator.init.arguments[0].id.name, '_callee');
     });
   });
+
+  describe("variables hoisting", function() {
+    it("shouldn't throw about duplicate bindings", function() {
+      // https://github.com/babel/babel/issues/6923
+
+      assert.doesNotThrow(function() {
+        compile([
+          "async function foo() {",
+          "  (async function (number) {",
+          "    const tmp = number",
+          "  })",
+          "}",
+        ].join("\n"));
+      });
+    })
+  });
 });

--- a/test/tests.transform.js
+++ b/test/tests.transform.js
@@ -242,14 +242,27 @@ context("functions", function() {
     it("shouldn't throw about duplicate bindings", function() {
       // https://github.com/babel/babel/issues/6923
 
+      const code = [
+        "async function foo() {",
+        "  (async function (number) {",
+        "    const tmp = number",
+        "  })",
+        "}",
+      ].join("\n");
+
       assert.doesNotThrow(function() {
-        compile([
-          "async function foo() {",
-          "  (async function (number) {",
-          "    const tmp = number",
-          "  })",
-          "}",
-        ].join("\n"));
+        const code = `
+          async function foo() {
+            (async function f(number) {
+              const tmp = number
+            })
+          }
+        `;
+
+        require("@babel/core").transformSync(code, {
+          configFile: false,
+          plugins: [require("..//packages/regenerator-transform")],
+        });
       });
     })
   });

--- a/test/tests.transform.js
+++ b/test/tests.transform.js
@@ -261,7 +261,7 @@ context("functions", function() {
 
         require("@babel/core").transformSync(code, {
           configFile: false,
-          plugins: [require("..//packages/regenerator-transform")],
+          plugins: [require("../packages/regenerator-transform")],
         });
       });
     })


### PR DESCRIPTION
Fixes babel/babel#6923, fixes babel/babel#8899, fixes babel/babel#8525

When hoisting variables, regenerator transforms`let a = 2;` to `a = 2;` and then injects `var a` at the beginning of the generator function scope.
Babel isn't really good at keeping the scope synchronized with the AST (and we won't fix it for a long time; it's probably the hardest thing to fix): for this reason, sometimes it throws when injecting `var a` because it thinks that `let a` is still there.
Manually removing the old bindings fixes the bug.

Note that this bug is only present when using `regenerator-transform` without `@babel/plugin-transform-block-scoping` (and thus it isn't reproducible when using `regenerator-preset`), because `@babel/plugin-transform-block-scoping` transforms `let`->`var` and `var`s can be duplicated.

From https://github.com/babel/babel/issues/6923:
```js
async function foo() {
	(async function (number) {
		const tmp = number
	})
}
```

Before this PR:
```
/home/nicolo/Documenti/dev/babel/babel/packages/babel-traverse/lib/scope/index.js:344
      throw this.hub.buildError(id, `Duplicate declaration "${name}"`, TypeError);
      ^

TypeError: undefined: Duplicate declaration "tmp" (This is an error on an internal node. Probably an internal error.)
    at File.buildCodeFrameError (/home/nicolo/Documenti/dev/babel/babel/packages/babel-core/lib/transformation/file/file.js:261:12)
    at Scope.checkBlockScopedCollisions (/home/nicolo/Documenti/dev/babel/babel/packages/babel-traverse/lib/scope/index.js:344:22)
    at Scope.registerBinding (/home/nicolo/Documenti/dev/babel/babel/packages/babel-traverse/lib/scope/index.js:501:16)
    at Scope.registerDeclaration (/home/nicolo/Documenti/dev/babel/babel/packages/babel-traverse/lib/scope/index.js:441:14)
    at Object.Declaration (/home/nicolo/Documenti/dev/babel/babel/packages/babel-traverse/lib/scope/index.js:125:12)
    at NodePath._call (/home/nicolo/Documenti/dev/babel/babel/packages/babel-traverse/lib/path/context.js:53:20)
    at NodePath.call (/home/nicolo/Documenti/dev/babel/babel/packages/babel-traverse/lib/path/context.js:40:17)
    at NodePath.visit (/home/nicolo/Documenti/dev/babel/babel/packages/babel-traverse/lib/path/context.js:88:12)
    at TraversalContext.visitQueue (/home/nicolo/Documenti/dev/babel/babel/packages/babel-traverse/lib/context.js:118:16)
    at TraversalContext.visitMultiple (/home/nicolo/Documenti/dev/babel/babel/packages/babel-traverse/lib/context.js:85:17)
```

After this PR:
```js
function foo() {
  return regeneratorRuntime.async(function foo$(_context2) {
    while (1) switch (_context2.prev = _context2.next) {
      case 0:
        (function f(number) {
          var tmp;
          return regeneratorRuntime.async(function f$(_context) {
            while (1) switch (_context.prev = _context.next) {
              case 0:
                tmp = number;

              case 1:
              case "end":
                return _context.stop();
            }
          });
        });

      case 1:
      case "end":
        return _context2.stop();
    }
  });
}
```