### PR TITLE
Register new bindings when hoisting vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,27 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+      "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/template": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "lodash": "^4.17.11"
+      }
+    },
     "@babel/helper-optimise-call-expression": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
@@ -136,6 +157,15 @@
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/traverse": "^7.4.4",
         "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+      "requires": {
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -246,6 +276,18 @@
       "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
+      "integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.4.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -457,6 +499,15 @@
       "resolved": "https://registry.npmjs.org/babel-check-duplicated-nodes/-/babel-check-duplicated-nodes-1.0.0.tgz",
       "integrity": "sha512-luUr6B28RzichAHdhCaGY6z53sm4+PAxzSedNlhZ9LtdW9txpR3G2Y5983iOnBosky88V08LeaUiDB/NR7vWvQ==",
       "dev": true
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@babel/parser": "^7.4.4",
+    "@babel/plugin-transform-modules-commonjs": "^7.5.0",
     "@babel/plugin-transform-parameters": "^7.4.4",
     "@babel/plugin-transform-spread": "^7.2.2",
     "babel-check-duplicated-nodes": "^1.0.0",

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -156,6 +156,9 @@ exports.getVisitor = ({ types: t }) => ({
 
       outerBody.push(t.returnStatement(wrapCall));
       node.body = t.blockStatement(outerBody);
+      // We injected a few new variable declarations (for every hoisted var),
+      // so we need to add them to the scope.
+      path.get("body.body").forEach(p => p.scope.registerDeclaration(p));
 
       const oldDirectives = bodyBlockPath.node.directives;
       if (oldDirectives) {


### PR DESCRIPTION
In https://github.com/facebook/regenerator/pull/368, I changed `regenerator-transform` to remove bindings which are hoisted, since it caused problems when they were registered again.
Nothing in this plugin actually registered them, but sometimes Babel re-traverses the scope and registers declaration which weren't already registerd (this usually happens when a function node is discarded and re-created, I think). For this reason, this code used to throw:
```js
async function foo() {
	(async function (number) {
		const tmp = number
	})
}
```
because when Babel did re-crawl the bindings, it already had a `tmp` binding registered (for `const tmp`) and tried to register a new one with the same name (for the hoisted `var tmp`).

Unfortunately we can't always rely on something to trigger the scope update, so simply deleting the old binding isn't enough. We also need to ensure that the new hoisted `var`s get registered again. Otherwise, we cause conflicts with the `transform-modules-commonjs` plugin (or any other plugin relying on scope information):

```js
import { someAction } from 'actions';

function* foo() {
  const someAction = bar;
}
```

This code is initially transformed by regenerator to something like this:

```js
import { someAction } from 'actions';

function foo() {
  var someAction;

  return regeneratorRuntime.wrap(function foo() {
    someAction = bar;
  });
}
```

it correctly removes the `const someAction` binding from the scope, but before this PR it didn't register the `var someAction` binding. For this reason, the modules transform plugin thought that `someAction = bar` was assigning to the imported binding (which is read-only), generating an error.

Fixes babel/babel#10193

---

PS: Do you have a custom `.npmrc` for this project on your machine? Every time I run `npm test` it generates `package-lock.json` files for the subpackages, and it changes the `dependencies` section in the top-level `package.json` file to reference the local packages.