### PR TITLE
add `.js` extension to file import

### DIFF
--- a/packages/regenerator-runtime/README.md
+++ b/packages/regenerator-runtime/README.md
@@ -21,7 +21,7 @@ following styles will work:
 require("regenerator-runtime/runtime");
 
 // ECMAScript 2015
-import "regenerator-runtime/runtime";
+import "regenerator-runtime/runtime.js";
 ```
 
 To get the absolute file system path of `runtime.js`, evaluate the


### PR DESCRIPTION
Importing files in a package requires explicit file extension unless it is defined as package exports, see https://nodejs.org/api/esm.html#esm_package_scope_and_file_extensions