### PR TITLE
Pass Promise as a parameter to regeneratorRuntime.async()

### DIFF
--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -207,7 +207,7 @@ var runtime = (function (exports) {
   // AsyncIterator objects; they just return a Promise for the value of
   // the final result produced by the iterator.
   exports.async = function(innerFn, outerFn, self, tryLocsList, PromiseImpl) {
-    if (PromiseImpl === undefined) PromiseImpl = Promise;
+    if (PromiseImpl === void 0) PromiseImpl = Promise;
 
     var iter = new AsyncIterator(
       wrap(innerFn, outerFn, self, tryLocsList),

--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -130,7 +130,7 @@ var runtime = (function (exports) {
     return { __await: arg };
   };
 
-  function AsyncIterator(generator) {
+  function AsyncIterator(generator, PromiseImpl) {
     function invoke(method, arg, resolve, reject) {
       var record = tryCatch(generator[method], generator, arg);
       if (record.type === "throw") {
@@ -141,14 +141,14 @@ var runtime = (function (exports) {
         if (value &&
             typeof value === "object" &&
             hasOwn.call(value, "__await")) {
-          return Promise.resolve(value.__await).then(function(value) {
+          return PromiseImpl.resolve(value.__await).then(function(value) {
             invoke("next", value, resolve, reject);
           }, function(err) {
             invoke("throw", err, resolve, reject);
           });
         }
 
-        return Promise.resolve(value).then(function(unwrapped) {
+        return PromiseImpl.resolve(value).then(function(unwrapped) {
           // When a yielded Promise is resolved, its final value becomes
           // the .value of the Promise<{value,done}> result for the
           // current iteration.
@@ -166,7 +166,7 @@ var runtime = (function (exports) {
 
     function enqueue(method, arg) {
       function callInvokeWithMethodAndArg() {
-        return new Promise(function(resolve, reject) {
+        return new PromiseImpl(function(resolve, reject) {
           invoke(method, arg, resolve, reject);
         });
       }
@@ -206,9 +206,12 @@ var runtime = (function (exports) {
   // Note that simple async functions are implemented on top of
   // AsyncIterator objects; they just return a Promise for the value of
   // the final result produced by the iterator.
-  exports.async = function(innerFn, outerFn, self, tryLocsList) {
+  exports.async = function(innerFn, outerFn, self, tryLocsList, PromiseImpl) {
+    if (PromiseImpl === undefined) PromiseImpl = Promise;
+
     var iter = new AsyncIterator(
-      wrap(innerFn, outerFn, self, tryLocsList)
+      wrap(innerFn, outerFn, self, tryLocsList),
+      PromiseImpl
     );
 
     return exports.isGeneratorFunction(outerFn)

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -134,7 +134,7 @@ exports.getVisitor = ({ types: t }) => ({
 
       if (node.generator) {
         wrapArgs.push(outerFnExpr);
-      } else if (context.usesThis || tryLocsList) {
+      } else if (context.usesThis || tryLocsList || node.async) {
         // Async functions that are not generators don't care about the
         // outer function because they don't need it to be marked and don't
         // inherit from its .prototype.
@@ -142,7 +142,7 @@ exports.getVisitor = ({ types: t }) => ({
       }
       if (context.usesThis) {
         wrapArgs.push(t.thisExpression());
-      } else if (tryLocsList) {
+      } else if (tryLocsList || node.async) {
         wrapArgs.push(t.nullLiteral());
       }
       if (tryLocsList) {

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -152,6 +152,8 @@ exports.getVisitor = ({ types: t }) => ({
       }
 
       if (node.async) {
+        // Rename any locally declared "Promise" variable,
+        // to use the global one.
         let currentScope = path.scope;
         do {
           if (currentScope.hasOwnBinding("Promise")) currentScope.rename("Promise");

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -147,6 +147,17 @@ exports.getVisitor = ({ types: t }) => ({
       }
       if (tryLocsList) {
         wrapArgs.push(tryLocsList);
+      } else if (node.async) {
+        wrapArgs.push(t.nullLiteral());
+      }
+
+      if (node.async) {
+        let currentScope = path.scope;
+        do {
+          if (currentScope.hasOwnBinding("Promise")) currentScope.rename("Promise");
+        } while (currentScope = currentScope.parent);
+
+        wrapArgs.push(t.identifier("Promise"));
       }
 
       let wrapCall = t.callExpression(

--- a/test/async-custom-promise.js
+++ b/test/async-custom-promise.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var assert = require("assert");
+
+function SyncPromise(run) {
+  this.resolved = null;
+  this.value = null;
+  try {
+    run(
+      val => { this.resolved = true; this.value = val; },
+      val => { this.resolved = false; this.value = val; }
+    );
+  } catch (e) {
+    this.resolved = false;
+    this.value = e;
+  }
+  if (this.resolved === null) {
+    throw new Error("SyncPromise must be run synchronously");
+  }
+  if (this.value instanceof SyncPromise) this.value = this.value.value;
+}
+SyncPromise.prototype.then = function(onRes, onRej) {
+  try {
+    if (this.resolved) return SyncPromise.resolve(onRes(this.value));
+    if (onRej) return SyncPromise.resolve(onRej(this.value));
+    return this;
+  } catch (e) {
+    return SyncPromise.reject(e);
+  }
+};
+SyncPromise.prototype.catch = function(onRej) {
+  try {
+    if (this.resolved) return this;
+    return SyncPromise.resolve(onRej(this.value));
+  } catch (e) {
+    return SyncPromise.reject(e);
+  }
+};
+SyncPromise.resolve = val => new SyncPromise(res => res(val));
+SyncPromise.reject = val => new SyncPromise((_, rej) => rej(val));
+
+describe("custom Promise polyfills", function() {
+  it("should work with async functions", function() {
+    babelInjectPromise: SyncPromise;
+
+    async function fn() {
+      var first = await SyncPromise.resolve(2);
+      var second = await 3;
+      return 4 * first * second;
+    }
+
+    assert.ok(fn() instanceof SyncPromise);
+    assert.ok(fn().resolved);
+    assert.strictEqual(fn().value, 24);
+  });
+
+  it("should correctly handle rejections", function() {
+    babelInjectPromise: SyncPromise;
+
+    async function fn() {
+      throw 2;
+    }
+
+    assert.ok(fn() instanceof SyncPromise);
+    assert.strictEqual(fn().resolved, false);
+    assert.strictEqual(fn().value, 2);
+  });
+
+  it("should work with async generators", function() {
+    babelInjectPromise: SyncPromise;
+
+    async function* fn() {
+      await 1;
+      var input = yield 2;
+      await 3;
+      return input;
+    }
+
+    var it = fn();
+    var val = it.next();
+
+    assert.ok(val instanceof SyncPromise);
+    assert.ok(val.resolved);
+    assert.deepStrictEqual(val.value, { done: false, value: 2 });
+
+    val = it.next(7);
+
+    assert.ok(val instanceof SyncPromise);
+    assert.ok(val.resolved);
+    assert.deepStrictEqual(val.value, { done: true, value: 7 });
+  });
+});


### PR DESCRIPTION
This makes it possible to run `@babel/plugin-transform-runtime` and `@babel/preset-env`'s `useBuiltIns` on `regenerator`'s output to provide a Promise polyfill in old browsers. 

Fixes babel/babel#10678, babel/babel#10830