### PR TITLE
Add array spread support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -192,14 +192,58 @@
       "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
     },
     "@babel/helper-replace-supers": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
-      "integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+      "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.8.3",
         "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.8.6"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
+          "integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+          "requires": {
+            "@babel/types": "^7.8.7",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
+          "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+        },
+        "@babel/traverse": {
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+          "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.6",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
+          "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-simple-access": {
@@ -300,24 +344,24 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.3.tgz",
-      "integrity": "sha512-SjT0cwFJ+7Rbr1vQsvphAHwUHvSUPmMjMU/0P59G8U2HLFqSa082JO7zkbDNWs9kH/IUqpHI6xWNesGf8haF1w==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.6.tgz",
+      "integrity": "sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.8.3",
         "@babel/helper-define-map": "^7.8.3",
         "@babel/helper-function-name": "^7.8.3",
         "@babel/helper-optimise-call-expression": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
         "@babel/helper-split-export-declaration": "^7.8.3",
         "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz",
-      "integrity": "sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.6.tgz",
+      "integrity": "sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
@@ -342,15 +386,6 @@
       "requires": {
         "@babel/helper-call-delegate": "^7.8.3",
         "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
-      }
-    },
-    "@babel/plugin-transform-spread": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
-      "integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
-      "dev": true,
-      "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
@@ -3635,9 +3670,7 @@
       }
     },
     "regenerator-preset": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-preset/-/regenerator-preset-0.13.2.tgz",
-      "integrity": "sha512-oPYBaPZx5VbkK1kxtImXNzfBwOQG25CIFm+vCKCSspAc8wSpts8aXWRKQTtcJtZ06ZvCYeMB9VFiOfpxLzSjcw==",
+      "version": "file:packages/regenerator-preset",
       "requires": {
         "@babel/plugin-proposal-function-sent": "^7.8.3",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -3649,14 +3682,10 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+      "version": "file:packages/regenerator-runtime"
     },
     "regenerator-transform": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.2.tgz",
-      "integrity": "sha512-V4+lGplCM/ikqi5/mkkpJ06e9Bujq1NFmNLvsCs56zg3ZbzrnUzAtizZ24TXxtRX/W2jcdScwQCnbL0CICTFkQ==",
+      "version": "file:packages/regenerator-transform",
       "requires": {
         "@babel/runtime": "^7.8.4",
         "private": "^0.1.8"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@babel/parser": "^7.8.4",
     "@babel/plugin-transform-modules-commonjs": "^7.8.3",
     "@babel/plugin-transform-parameters": "^7.8.4",
-    "@babel/plugin-transform-spread": "^7.8.3",
     "babel-check-duplicated-nodes": "^1.0.0",
     "browserify": "^16.5.0",
     "mocha": "^7.0.1",

--- a/packages/regenerator-transform/src/emit.js
+++ b/packages/regenerator-transform/src/emit.js
@@ -1092,7 +1092,13 @@ Ep.explodeExpression = function(path, ignoreResult) {
   case "ArrayExpression":
     return finish(t.arrayExpression(
       path.get("elements").map(function(elemPath) {
-        return explodeViaTempVar(null, elemPath);
+        if (elemPath.isSpreadElement()) {
+          return t.spreadElement(
+            explodeViaTempVar(null, elemPath.get("argument"))
+          );
+        } else {
+          return explodeViaTempVar(null, elemPath);
+        }
       })
     ));
 

--- a/test/run.js
+++ b/test/run.js
@@ -165,11 +165,10 @@ enqueue(convert, [
   "./test/class.es5.js"
 ]);
 
-function convertWithSpread(es6File, es5File, callback) {
+function convertWithParamsTransform(es6File, es5File, callback) {
   var transformOptions = {
     presets:[require("regenerator-preset")],
     plugins: [
-      require("@babel/plugin-transform-spread"),
       require("@babel/plugin-transform-parameters")
     ],
     parserOpts: {
@@ -200,7 +199,7 @@ function convertWithSpread(es6File, es5File, callback) {
   });
 }
 
-enqueue(convertWithSpread, [
+enqueue(convertWithParamsTransform, [
   "./test/regression.js",
   "./test/regression.es5.js"
 ]);

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -2742,4 +2742,22 @@ describe("expressions containing yield subexpressions", function() {
       done: true
     });
   });
+
+  it("should work when yield is in an array spread", function() {
+    function *gen() {
+      return [0, ...(yield "foo"), 3];
+    }
+
+    var g = gen();
+
+    assert.deepEqual(g.next(), {
+      value: "foo",
+      done: false,
+    });
+
+    assert.deepEqual(g.next([1, 2]), {
+      value: [0, 1, 2, 3],
+      done: true,
+    });
+  });
 });


### PR DESCRIPTION
There are some browsers that support array spread but don't support generators.

**Why did we never realize it?**

The browsers versions that support array spread and the versions that supports generators are _close_:

```json
"transform-spread": {
  "chrome": "46",
  "edge": "13",
  "firefox": "36",
  "safari": "10",
  "node": "5",
  "ios": "10",
  "samsung": "5",
  "opera": "33",
  "electron": "0.36"
},
"transform-regenerator": {
  "chrome": "50",
  "edge": "13",
  "firefox": "53",
  "safari": "10",
  "node": "6",
  "ios": "10",
  "samsung": "5",
  "opera": "37",
  "electron": "1.1"
},
```

Probably no one ever used a browsers query in `preset-env` that included `transform-regenerator` but not `transform-spread`.

**Why did we found this bug now?**

`create-react-app` defaults to `>0.2%, not dead, not op_mini all` for browsers support. Some users additionally exclude IE 11 and Safari 5.1, since they are really old and force the inclusion of a lot of different transforms.
Due to some recent changes in the usage data on caniuse/browserslist (an old browser felt below 0.2%, or it become "dead"), this currently matches [these browsers](https://browsersl.ist/?q=%3E0.2%25):
- Chrome 49
- Edge 17
- Firefox 70
- Opera 63
- Safari 11.1

These browsers need `transform-regenerator` (because of Chrome 49), but they don't need `transform-spread`.

**Alternative solution**

We could force `transform-spread` when using `transform-regenerator` in `preset-env`, but I'd avoid forcing an unnecessary transform if possible.

---

Fixes https://github.com/babel/babel/issues/11212