### PR TITLE
Remove _shadowFunctionLiteral use

### DIFF
--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -114,11 +114,9 @@ exports.getVisitor = ({ types: t }) => ({
 
       if (context.usesArguments) {
         vars = vars || t.variableDeclaration("var", []);
-        const argumentIdentifier = t.identifier("arguments");
-        // we need to do this as otherwise arguments in arrow functions gets hoisted
-        argumentIdentifier._shadowedFunctionLiteral = path;
         vars.declarations.push(t.variableDeclarator(
-          t.clone(argsId), argumentIdentifier
+          t.clone(argsId),
+          t.identifier("arguments"),
         ));
       }
 

--- a/test/tests.transform.js
+++ b/test/tests.transform.js
@@ -7,6 +7,7 @@
 
 var assert = require("assert");
 var recast = require("recast");
+var v8 = require("v8");
 var types = recast.types;
 var n = types.namedTypes;
 var transform = require("..").transform;
@@ -331,3 +332,30 @@ context("functions", function() {
     });
   });
 });
+
+describe("ast serialization", function() {
+  function getAST() {
+    return require("@babel/core").transformSync(
+`function* foo() {
+  arguments;
+}`,
+      {
+        ast: true,
+        configFile: false,
+        plugins: [require("../packages/regenerator-transform")],
+      },
+    ).ast;
+  }
+
+  it("produces an ast that is JSON serializable", function() {
+    assert.doesNotThrow(function() {
+      JSON.stringify(getAST());
+    });
+  })
+
+  it("produces an ast that is serializable with v8's serializer", function() {
+    assert.doesNotThrow(function() {
+      v8.serialize(getAST());
+    });
+  })
+})


### PR DESCRIPTION
Closes #387. Additional context is available there.

This removes the use of attaching a `_shadowFunctionLiteral` property with a `NodePath` value to a `Node`, which prevents Babel ASTs from being serialized. It doesn't appear to be used by Babel any longer and tests still pass.

Test Plan: `npm test`. Tests enforcing the Babel ast can be serialized were added. Existing tests continue to pass.