### PR TITLE
polish: print friendly error when hoisting unsupported node types

### DIFF
--- a/packages/regenerator-transform/src/hoist.js
+++ b/packages/regenerator-transform/src/hoist.js
@@ -24,6 +24,10 @@ exports.hoist = function(funPath) {
     let exprs = [];
 
     vdec.declarations.forEach(function(dec) {
+      if (!t.isIdentifier(dec.id)) {
+        // We don't support ArrayPattern and ObjectPattern
+        throw new Error("Unsupported declarator with type " + JSON.stringify(dec.id.type) + ", please add \"@babel/plugin-transform-destructuring\" to your babel config.")
+      }
       // Note: We duplicate 'dec.id' here to ensure that the variable declaration IDs don't
       // have the same 'loc' value, since that can make sourcemaps and retainLines behave poorly.
       vars[dec.id.name] = t.identifier(dec.id.name);


### PR DESCRIPTION
Context: https://github.com/babel/babel/issues/10808

Transform the following snippet with only `regenerator-transform`
```js
async (req) => {
  const { params } = req;
}
```
 will throw
```
TypeError: /src.js: Property name expected type of string but got null
    at validate (/node_modules/@babel/types/lib/definitions/utils.js:164:13)
    at Object.validate (/node_modules/@babel/types/lib/definitions/utils.js:201:7)
    at validateField (node_modules/@babel/types/lib/validators/validate.js:22:9)
    at validate (/node_modules/@babel/types/lib/validators/validate.js:16:3)
    at builder (/node_modules/@babel/types/lib/builders/builder.js:38:27)
    at Object.Identifier (/node_modules/@babel/types/lib/builders/generated/index.js:334:31)
    at /node_modules/regenerator-transform/lib/hoist.js:32:29
```

Since practically every engine with native destructuring support will also have native generator support ([thread](https://github.com/babel/babel/issues/10808#issuecomment-611119555)). I think the value of pattern support is marginal. Hence we throw a better error.