### PR TITLE
Relieve dependency on private package

### DIFF
--- a/packages/regenerator-transform/package.json
+++ b/packages/regenerator-transform/package.json
@@ -32,8 +32,7 @@
     ]
   },
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
-    "private": "^0.1.8"
+    "@babel/runtime": "^7.8.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/regenerator-transform/src/meta.js
+++ b/packages/regenerator-transform/src/meta.js
@@ -7,10 +7,16 @@
 
 import assert from "assert";
 import { getTypes } from "./util.js";
-import { makeAccessor } from "private";
 
-let m = makeAccessor();
-let hasOwn = Object.prototype.hasOwnProperty;
+const mMap = new WeakMap();
+function m(node) {
+  if (!mMap.has(node)) {
+    mMap.set(node, {});
+  }
+  return mMap.get(node);
+}
+
+const hasOwn = Object.prototype.hasOwnProperty;
 
 function makePredicate(propertyName, knownTypes) {
   function onlyChildren(node) {

--- a/packages/regenerator-transform/src/visit.js
+++ b/packages/regenerator-transform/src/visit.js
@@ -12,7 +12,6 @@ import { hoist } from "./hoist";
 import { Emitter } from "./emit";
 import replaceShorthandObjectMethod from "./replaceShorthandObjectMethod";
 import * as util from "./util";
-import { makeAccessor } from "private";
 
 exports.getVisitor = ({ types: t }) => ({
   Method(path, state) {
@@ -255,7 +254,14 @@ function getOuterFnExpr(funPath) {
   return t.clone(node.id);
 }
 
-const getMarkInfo = makeAccessor();
+const markInfo = new WeakMap();
+
+function getMarkInfo(node) {
+  if (!markInfo.has(node)) {
+    markInfo.set(node, {});
+  }
+  return markInfo.get(node);
+}
 
 function getMarkedFunctionId(funPath) {
   const t = util.getTypes();


### PR DESCRIPTION
Modern JS engines now support WeakMap.  WeakMaps solve the same problem as the private package, but without needing to tamper with intrinsics to ensure their privacy.

Relaxing this dependency eases compatibility with SES (a secure ECMAScript subset that leaves intrinsics immutable).