### PR TITLE
runtime: Use `[[Define]]` for the `Symbol.toStringTag` property

### DIFF
--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -8,6 +8,21 @@
 var runtime = (function (exports) {
   "use strict";
 
+  // Inlined from `@babel/runtime/helpers/defineProperty`
+  function _defineProperty(obj, key, value) {
+    if (key in obj) {
+      Object.defineProperty(obj, key, {
+        value: value,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+    } else {
+      obj[key] = value;
+    }
+    return obj;
+  }
+
   var Op = Object.prototype;
   var hasOwn = Op.hasOwnProperty;
   var undefined; // More compressible than void 0.
@@ -386,7 +401,7 @@ var runtime = (function (exports) {
   // unified ._invoke helper method.
   defineIteratorMethods(Gp);
 
-  Gp[toStringTagSymbol] = "Generator";
+  _defineProperty(Gp, toStringTagSymbol, "Generator");
 
   // A Generator should always return itself as the iterator object when the
   // @@iterator function is called on it. Some browsers' implementations of the

--- a/test/non-writable-tostringtag-property.js
+++ b/test/non-writable-tostringtag-property.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var hasOwn = Object.prototype.hasOwnProperty;
+var getProto = Object.getPrototypeOf;
+var NativeIteratorPrototype =
+  typeof Symbol === "function" &&
+  typeof Symbol.iterator === "symbol" &&
+  typeof [][Symbol.iterator] === "function" &&
+  getProto &&
+  getProto(getProto([][Symbol.iterator]()));
+
+// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype-@@tostringtag
+Object.defineProperty(NativeIteratorPrototype, Symbol.toStringTag, {
+  configurable: true,
+  value: "Iterator",
+});
+
+it("regenerator-runtime doesn't fail to initialize when native iterator prototype has a non-writable @@toStringTag property", function() {
+  require("./runtime.js");
+});

--- a/test/run.js
+++ b/test/run.js
@@ -133,6 +133,14 @@ if (semver.gte(process.version, "4.0.0")) {
   ]);
 }
 
+if (semver.gte(process.version, "4.0.0")) {
+  enqueue("mocha", [
+    "--harmony",
+    "--reporter", "spec",
+    "./test/non-writable-tostringtag-property.js",
+  ]);
+}
+
 enqueue(convert, [
   "./test/tests.es6.js",
   "./test/tests.es5.js"


### PR DESCRIPTION
See <https://github.com/tc39/proposal-iterator-helpers/issues/115> and **Firefox**’s [Bug 1644581 (comment #6)](https://bugzilla.mozilla.org/show_bug.cgi?id=1644581#c6).