### PR TITLE
[Fix] conditionally set `Symbol.toStringTag`, since it's nonwritable

### DIFF
--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -82,14 +82,21 @@ var runtime = (function (exports) {
     IteratorPrototype = NativeIteratorPrototype;
   }
 
+  function ensureDefaultToStringTag(object, defaultValue) {
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1644581#c6
+    return toStringTagSymbol in object
+      ? object[toStringTagSymbol]
+      : object[toStringTagSymbol] = defaultValue;
+  }
+
   var Gp = GeneratorFunctionPrototype.prototype =
     Generator.prototype = Object.create(IteratorPrototype);
   GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
   GeneratorFunctionPrototype.constructor = GeneratorFunction;
-  if (!(toStringTagSymbol in GeneratorFunctionPrototype)) {
-    GeneratorFunctionPrototype[toStringTagSymbol] = "GeneratorFunction";
-  }
-  GeneratorFunction.displayName = GeneratorFunctionPrototype[toStringTagSymbol];
+  GeneratorFunction.displayName = ensureDefaultToStringTag(
+    GeneratorFunctionPrototype,
+    "GeneratorFunction"
+  );
 
   // Helper for defining the .next, .throw, and .return methods of the
   // Iterator interface in terms of a single ._invoke method.
@@ -116,9 +123,7 @@ var runtime = (function (exports) {
       Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
     } else {
       genFun.__proto__ = GeneratorFunctionPrototype;
-      if (!(toStringTagSymbol in genFun)) {
-        genFun[toStringTagSymbol] = "GeneratorFunction";
-      }
+      ensureDefaultToStringTag(genFun, "GeneratorFunction");
     }
     genFun.prototype = Object.create(Gp);
     return genFun;
@@ -388,9 +393,7 @@ var runtime = (function (exports) {
   // unified ._invoke helper method.
   defineIteratorMethods(Gp);
 
-  if (!(toStringTagSymbol in Gp)) {
-    Gp[toStringTagSymbol] = "Generator";
-  }
+  ensureDefaultToStringTag(Gp, "Generator");
 
   // A Generator should always return itself as the iterator object when the
   // @@iterator function is called on it. Some browsers' implementations of the

--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -86,8 +86,10 @@ var runtime = (function (exports) {
     Generator.prototype = Object.create(IteratorPrototype);
   GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
   GeneratorFunctionPrototype.constructor = GeneratorFunction;
-  GeneratorFunctionPrototype[toStringTagSymbol] =
-    GeneratorFunction.displayName = "GeneratorFunction";
+  if (!(toStringTagSymbol in GeneratorFunctionPrototype)) {
+    GeneratorFunctionPrototype[toStringTagSymbol] = "GeneratorFunction";
+  }
+  GeneratorFunction.displayName = GeneratorFunctionPrototype[toStringTagSymbol];
 
   // Helper for defining the .next, .throw, and .return methods of the
   // Iterator interface in terms of a single ._invoke method.
@@ -386,7 +388,9 @@ var runtime = (function (exports) {
   // unified ._invoke helper method.
   defineIteratorMethods(Gp);
 
-  Gp[toStringTagSymbol] = "Generator";
+  if (!(toStringTagSymbol in Gp)) {
+    Gp[toStringTagSymbol] = "Generator";
+  }
 
   // A Generator should always return itself as the iterator object when the
   // @@iterator function is called on it. Some browsers' implementations of the

--- a/test/non-writable-tostringtag-property.js
+++ b/test/non-writable-tostringtag-property.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var hasOwn = Object.prototype.hasOwnProperty;
+var getProto = Object.getPrototypeOf;
+var NativeIteratorPrototype =
+  typeof Symbol === "function" &&
+  typeof Symbol.iterator === "symbol" &&
+  typeof [][Symbol.iterator] === "function" &&
+  getProto &&
+  getProto(getProto([][Symbol.iterator]()));
+
+// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype-@@tostringtag
+Object.defineProperty(NativeIteratorPrototype, Symbol.toStringTag, {
+  configurable: true,
+  value: "Iterator",
+});
+
+describe("Symbol.toStringTag safety (#399, #400)", function () {
+  it("regenerator-runtime doesn't fail to initialize when native iterator prototype has a non-writable @@toStringTag property", function() {
+    require("./runtime.js");
+  });
+});

--- a/test/run.js
+++ b/test/run.js
@@ -133,6 +133,14 @@ if (semver.gte(process.version, "4.0.0")) {
   ]);
 }
 
+if (semver.gte(process.version, "4.0.0")) {
+  enqueue("mocha", [
+    "--harmony",
+    "--reporter", "spec",
+    "./test/non-writable-tostringtag-property.js",
+  ]);
+}
+
 enqueue(convert, [
   "./test/tests.es6.js",
   "./test/tests.es5.js"


### PR DESCRIPTION
This avoids an exception when the new iterator helpers proposal provides a spec-compliant nonwritable Symbol.toStringTag property.

See https://github.com/tc39/proposal-iterator-helpers/issues/115 and https://bugzilla.mozilla.org/show_bug.cgi?id=1644581#c6.

Closes #399.