### PR TITLE
runtime: Use `[[Define]]` for the `Symbol.toStringTag` property

### DIFF
--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -8,6 +8,7 @@
 var runtime = (function (exports) {
   "use strict";
 
+  var define = Object.defineProperty;
   var Op = Object.prototype;
   var hasOwn = Op.hasOwnProperty;
   var undefined; // More compressible than void 0.
@@ -15,6 +16,15 @@ var runtime = (function (exports) {
   var iteratorSymbol = $Symbol.iterator || "@@iterator";
   var asyncIteratorSymbol = $Symbol.asyncIterator || "@@asyncIterator";
   var toStringTagSymbol = $Symbol.toStringTag || "@@toStringTag";
+
+  if (define) {
+    try {
+      // IE 8 has a broken Object.defineProperty that only works on DOM objects
+      define({}, '', {});
+    } catch (err) {
+      define = undefined;
+    }
+  }
 
   function wrap(innerFn, outerFn, self, tryLocsList) {
     // If outerFn provided and outerFn.prototype is a Generator, then outerFn.prototype instanceof Generator.
@@ -85,7 +95,13 @@ var runtime = (function (exports) {
   function ensureDefaultToStringTag(object, defaultValue) {
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1644581#c6
     return toStringTagSymbol in object
-      ? object[toStringTagSymbol]
+      ? (define && define(object, toStringTagSymbol, {
+          value: defaultValue,
+          enumerable: true,
+          configurable: true,
+          writable: true
+        }),
+        defaultValue)
       : object[toStringTagSymbol] = defaultValue;
   }
 

--- a/test/non-writable-tostringtag-property.js
+++ b/test/non-writable-tostringtag-property.js
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var hasOwn = Object.prototype.hasOwnProperty;
+var assert = require("assert");
+
 var getProto = Object.getPrototypeOf;
 var NativeIteratorPrototype =
   typeof Symbol === "function" &&
@@ -20,8 +21,16 @@ Object.defineProperty(NativeIteratorPrototype, Symbol.toStringTag, {
   value: "Iterator",
 });
 
-describe("Symbol.toStringTag safety (#399, #400)", function () {
+(NativeIteratorPrototype ? describe : describe.skip)("Symbol.toStringTag safety (#399, #400)", function () {
   it("regenerator-runtime doesn't fail to initialize when native iterator prototype has a non-writable @@toStringTag property", function() {
     require("./runtime.js");
+  });
+
+  it("regenerator-runtime's polyfilled generator prototype has the correct @@toStringTag value", function() {
+    require("./runtime.js");
+    function foo() {}
+    regeneratorRuntime.mark(foo);
+
+    assert.strictEqual(foo.prototype[Symbol.toStringTag], "Generator");
   });
 });


### PR DESCRIPTION
PR <https://github.com/facebook/regenerator/pull/400> makes it so that once engines start shipping `Iterator.prototype[Symbol.toStringTag]`, then `Object.prototype.toString` will return `[object Iterator]` instead of `[object Generator]` for regenerator’s generator objects.

This fixes that to ensure that it doesn’t happen.