### PR TITLE
Runtime - Support frozen intrinsics

### DIFF
--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -102,8 +102,9 @@ var runtime = (function (exports) {
 
   var Gp = GeneratorFunctionPrototype.prototype =
     Generator.prototype = Object.create(IteratorPrototype);
-  GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
-  GeneratorFunctionPrototype.constructor = GeneratorFunction;
+  GeneratorFunction.prototype = GeneratorFunctionPrototype;
+  define(Gp, "constructor", GeneratorFunctionPrototype);
+  define(GeneratorFunctionPrototype, "constructor", GeneratorFunction);
   GeneratorFunction.displayName = define(
     GeneratorFunctionPrototype,
     toStringTagSymbol,
@@ -416,9 +417,9 @@ var runtime = (function (exports) {
     return this;
   };
 
-  Gp.toString = function() {
+  define(Gp, 'toString', function() {
     return "[object Generator]";
-  };
+  });
 
   function pushTryEntry(locs) {
     var entry = { tryLoc: locs[0] };

--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -86,9 +86,9 @@ var runtime = (function (exports) {
   // This is a polyfill for %IteratorPrototype% for environments that
   // don't natively support it.
   var IteratorPrototype = {};
-  IteratorPrototype[iteratorSymbol] = function () {
+  define(IteratorPrototype, iteratorSymbol, function () {
     return this;
-  };
+  });
 
   var getProto = Object.getPrototypeOf;
   var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
@@ -218,9 +218,9 @@ var runtime = (function (exports) {
   }
 
   defineIteratorMethods(AsyncIterator.prototype);
-  AsyncIterator.prototype[asyncIteratorSymbol] = function () {
+  define(AsyncIterator.prototype, asyncIteratorSymbol, function () {
     return this;
-  };
+  });
   exports.AsyncIterator = AsyncIterator;
 
   // Note that simple async functions are implemented on top of
@@ -413,11 +413,11 @@ var runtime = (function (exports) {
   // iterator prototype chain incorrectly implement this, causing the Generator
   // object to not be returned from this call. This ensures that doesn't happen.
   // See https://github.com/facebook/regenerator/issues/274 for more details.
-  Gp[iteratorSymbol] = function() {
+  define(Gp, iteratorSymbol, function() {
     return this;
-  };
+  });
 
-  define(Gp, 'toString', function() {
+  define(Gp, "toString", function() {
     return "[object Generator]";
   });
 

--- a/test/frozen-intrinsics.js
+++ b/test/frozen-intrinsics.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var assert = require("assert");
+
+Object.freeze(Object.prototype)
+
+
+describe("Frozen intrinsics test", function () {
+  it("regenerator-runtime doesn't fail to initialize when Object prototype is frozen", function() {
+    require("./runtime.js");
+  });
+});

--- a/test/frozen-intrinsics.js
+++ b/test/frozen-intrinsics.js
@@ -7,8 +7,30 @@
 
 var assert = require("assert");
 
-Object.freeze(Object.prototype)
+var getPrototypeOf = Reflect.getPrototypeOf;
+function getConstructorOf(obj) {
+  return getPrototypeOf(obj).constructor;
+}
 
+var SymbolIterator = (typeof Symbol && Symbol.iterator) || '@@iterator';
+var ArrayIteratorObject = new Array()[SymbolIterator]();
+var ArrayIteratorPrototype = getPrototypeOf(ArrayIteratorObject);
+var IteratorPrototype = getPrototypeOf(ArrayIteratorPrototype);
+async function* AsyncGeneratorFunctionInstance() {}
+var AsyncGeneratorFunction = getConstructorOf(
+  AsyncGeneratorFunctionInstance,
+);
+var AsyncGenerator = AsyncGeneratorFunction.prototype;
+var AsyncGeneratorPrototype = AsyncGenerator.prototype;
+var AsyncIteratorPrototype = getPrototypeOf(AsyncGeneratorPrototype);
+
+// freeze relevant intrinsics
+Object.freeze(Object.prototype);
+Object.freeze(IteratorPrototype);
+Object.freeze(ArrayIteratorPrototype);
+Object.freeze(AsyncGenerator);
+Object.freeze(AsyncGeneratorPrototype);
+Object.freeze(AsyncIteratorPrototype);
 
 describe("Frozen intrinsics test", function () {
   it("regenerator-runtime doesn't fail to initialize when Object prototype is frozen", function() {

--- a/test/run.js
+++ b/test/run.js
@@ -141,6 +141,12 @@ if (semver.gte(process.version, "4.0.0")) {
   ]);
 }
 
+enqueue("mocha", [
+  "--harmony",
+  "--reporter", "spec",
+  "./test/frozen-intrinsics.js",
+]);
+
 enqueue(convert, [
   "./test/tests.es6.js",
   "./test/tests.es5.js"


### PR DESCRIPTION
Fixes #410 

thanks for taking the time to review this change :heart: 
I wasn't sure exactly what platform to target with the tests, feedback welcome

these seemed like the least invasive change to make this work
I tested this locally against a more significant freezing of the intrinsics, built from nodejs internal [freeze_intrinsics](https://github.com/nodejs/node/blob/7c808170f5bf27b2d4a83ae5934b5e231bb5c1bc/lib/internal/freeze_intrinsics.js) and [primordials](https://github.com/nodejs/node/blob/7c808170f5bf27b2d4a83ae5934b5e231bb5c1bc/lib/internal/per_context/primordials.js)
here is a draft PR that includes those additional test utilities https://github.com/facebook/regenerator/pull/412
those tests pass with no additional change to the runtime