### PR TITLE
Failing test of class computed method name yield with argument.

### DIFF
--- a/test/class.js
+++ b/test/class.js
@@ -119,4 +119,30 @@ describe("class methods", function () {
     assert.strictEqual(new res().one(), 1);
     assert.strictEqual(new res().two(), 2);
   });
+
+  it("should allow computed method keys containing yield with argument", function () {
+    function *gen(prefix) {
+      return class Foo {
+        [yield "array iterator"](x) {
+          return [prefix + x][Symbol.iterator]();
+        }
+
+        *[yield "generator method"](x) {
+          yield (prefix + x);
+        }
+      }
+    }
+
+    const g = gen("prefix:");
+
+    assert.deepEqual(g.next(), { value: "array iterator", done: false });
+    assert.deepEqual(g.next("arr"), { value: "generator method", done: false });
+
+    const { value: Foo, done } = g.next("gen");
+    assert.strictEqual(done, true);
+
+    const foo = new Foo();
+    check(foo.arr("xxx"), ["prefix:xxx"]);
+    check(foo.gen("yyy"), ["prefix:yyy"]);
+  });
 });


### PR DESCRIPTION
I was tempted to add this test to #408, but after some debugging I believe this is a bug with `@babel/plugin-transform-classes`, as demonstrated by [this babeljs.io/repl example](https://babeljs.io/repl/#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.6&spec=false&loose=false&code_lz=GYVwdgxgLglg9mABAKgOYFMwAoCUiDeAUIogE7pQilIQA2AhgM6MHEkoDaAnjOrQCaIAjACYAzAF0sADzxF27cpWqIefQdIDcbEgF82-3UA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact%2Cstage-2&prettier=false&targets=&version=7.14.8&externalPlugins=%40babel%2Fplugin-transform-classes%407.14.5).

Specifically, when this code is compiled with only `@babel/plugin-transform-classes`:
```js
function *gen() {
  return class {
    *[yield 123](x) {
      return yield x;
    }
  }
}
```
the generated code wraps the class creation code in a non-generator function expression, but accidentally preserves the `yield 123` expression within that function:
```js
function* gen() {
  return /*#__PURE__*/function () {
    function _class() {
      _classCallCheck(this, _class);
    }

    _createClass(_class, [{
      key: yield 123, // Parse error!
      value: function* (x) {
        return yield x;
      }
    }]);

    return _class;
  }();
}
```
If Regenerator is used without the class transform, everything works (thanks to #408; see `test/class.regenerator.js`).

To get this right, I think we would want to generate the following code (or something similar):
```js
function* gen() {
  return /*#__PURE__*/function (t0) {
    function _class() {
      _classCallCheck(this, _class);
    }

    _createClass(_class, [{
      key: t0,
      value: function* (x) {
        return yield x;
      }
    }]);

    return _class;
  }(yield 123);
}
```
Passing arguments to the IIFE makes sense to me because that's how `extends` superclass expressions are handled, but if the combination of those features is tricky for some reason, the following code could work as well:
```js
function* gen() {
  const t0 = yield 123;
  return /*#__PURE__*/function () {
    function _class() {
      _classCallCheck(this, _class);
    }

    _createClass(_class, [{
      key: t0,
      value: function* (x) {
        return yield x;
      }
    }]);

    return _class;
  }();
}
```
@nicolo-ribaudo I can file this bug over at the Babel repo, but let me know if you have any other ideas!