### PR TITLE
hide constructor property from prototype

### DIFF
--- a/packages/runtime/runtime.js
+++ b/packages/runtime/runtime.js
@@ -104,8 +104,12 @@ var runtime = (function (exports) {
   var Gp = GeneratorFunctionPrototype.prototype =
     Generator.prototype = Object.create(IteratorPrototype);
   GeneratorFunction.prototype = GeneratorFunctionPrototype;
-  define(Gp, "constructor", GeneratorFunctionPrototype);
-  define(GeneratorFunctionPrototype, "constructor", GeneratorFunction);
+  defineProperty(Gp, "constructor", { value: GeneratorFunctionPrototype, configurable: true });
+  defineProperty(
+    GeneratorFunctionPrototype,
+    "constructor",
+    { value: GeneratorFunction, configurable: true }
+  );
   GeneratorFunction.displayName = define(
     GeneratorFunctionPrototype,
     toStringTagSymbol,


### PR DESCRIPTION
Fixes https://github.com/babel/babel/issues/14978. Per [spec](https://tc39.es/ecma262/#sec-generator.prototype.constructor), the `constructor` property is now marked as non-numerable and non-writable.