### PR TITLE
Fix regenerator packages resolution

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,6 +25,8 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Use latest npm
+      run: npm install --global npm@latest
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "commoner": "^0.10.8",
         "private": "^0.1.8",
         "recast": "^0.21.5",
-        "regenerator-preset": "file:packages/preset",
-        "regenerator-runtime": "file:packages/runtime",
-        "regenerator-transform": "file:packages/transform",
+        "regenerator-preset": "^0.14.0",
+        "regenerator-runtime": "^0.13.10",
+        "regenerator-transform": "^0.15.0",
         "through": "^2.3.8"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "commoner": "^0.10.8",
     "private": "^0.1.8",
     "recast": "^0.21.5",
-    "regenerator-preset": "file:packages/preset",
-    "regenerator-runtime": "file:packages/runtime",
-    "regenerator-transform": "file:packages/transform",
+    "regenerator-preset": "^0.14.0",
+    "regenerator-runtime": "^0.13.10",
+    "regenerator-transform": "^0.15.0",
     "through": "^2.3.8"
   },
   "devDependencies": {

--- a/test/run.sh
+++ b/test/run.sh
@@ -18,10 +18,14 @@ install() {
     popd
 }
 
+PKG=$(<package.json)
+
 # Link local packages into node_modules.
 install runtime
 install transform
 install preset
+
+echo "$PKG" > package.json
 
 # We need to use the symlink paths rather than the real paths, so that the
 # regenerator-* packages appear to reside in node_modules.

--- a/test/run.sh
+++ b/test/run.sh
@@ -19,6 +19,7 @@ install() {
 }
 
 PKG=$(<package.json)
+PKG_LOCK=$(<package-lock.json)
 
 # Link local packages into node_modules.
 install runtime
@@ -26,6 +27,7 @@ install transform
 install preset
 
 echo "$PKG" > package.json
+echo "$PKG_LOCK" > package-lock.json
 
 # We need to use the symlink paths rather than the real paths, so that the
 # regenerator-* packages appear to reside in node_modules.


### PR DESCRIPTION
Fix for the latest release version `0.14.8` which includes wrong `file:` protocol resolutions for internal regenerator packages: 3c485a0cf52cbd43dfddc33f83a84c6d8e0caf6f. Local path resolutions do not work when publishing packages to the public registry:
- https://docs.npmjs.com/cli/v8/configuring-npm/package-json#local-paths

Fixes #613