### PR TITLE
Fix `npm ci` failures from PR #616 by installing latest npm

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,6 +25,8 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Use latest npm
+      run: npm install --global npm@latest
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "commoner": "^0.10.8",
         "private": "^0.1.8",
         "recast": "^0.21.5",
-        "regenerator-preset": "file:packages/preset",
-        "regenerator-runtime": "file:packages/runtime",
-        "regenerator-transform": "file:packages/transform",
+        "regenerator-preset": "^0.14.0",
+        "regenerator-runtime": "^0.13.10",
+        "regenerator-transform": "^0.15.0",
         "through": "^2.3.8"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "commoner": "^0.10.8",
     "private": "^0.1.8",
     "recast": "^0.21.5",
-    "regenerator-preset": "file:packages/preset",
-    "regenerator-runtime": "file:packages/runtime",
-    "regenerator-transform": "file:packages/transform",
+    "regenerator-preset": "^0.14.0",
+    "regenerator-runtime": "^0.13.10",
+    "regenerator-transform": "^0.15.0",
     "through": "^2.3.8"
   },
   "devDependencies": {

--- a/test/run.sh
+++ b/test/run.sh
@@ -18,10 +18,14 @@ install() {
     popd
 }
 
+PKG=$(<package.json)
+
 # Link local packages into node_modules.
 install runtime
 install transform
 install preset
+
+echo "$PKG" > package.json
 
 # We need to use the symlink paths rather than the real paths, so that the
 # regenerator-* packages appear to reside in node_modules.

--- a/test/run.sh
+++ b/test/run.sh
@@ -19,6 +19,7 @@ install() {
 }
 
 PKG=$(<package.json)
+PKG_LOCK=$(<package-lock.json)
 
 # Link local packages into node_modules.
 install runtime
@@ -26,6 +27,7 @@ install transform
 install preset
 
 echo "$PKG" > package.json
+echo "$PKG_LOCK" > package-lock.json
 
 # We need to use the symlink paths rather than the real paths, so that the
 # regenerator-* packages appear to reside in node_modules.


### PR DESCRIPTION
For example:
https://github.com/facebook/regenerator/actions/runs/3266480308/jobs/5370267573

```
> Run npm ci
  npm ci
  shell: /usr/bin/bash -e {0}
npm ERR! Invalid Version: file:packages/preset

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/[2](https://github.com/facebook/regenerator/actions/runs/3266480308/jobs/5370267573#step:4:2)022-10-17T15_[3](https://github.com/facebook/regenerator/actions/runs/3266480308/jobs/5370267573#step:4:3)0_[4](https://github.com/facebook/regenerator/actions/runs/3266480308/jobs/5370267573#step:4:5)3_6[5](https://github.com/facebook/regenerator/actions/runs/3266480308/jobs/5370267573#step:4:6)4Z-debug.log
Error: Process completed with exit code 1.
```

Since there are no longer any occurrences of `file:packages/preset` in the codebase (thanks to PR #616), I'm wondering if some sort of GitHub Actions caching is causing old code to reappear. Hopefully running the tests on a new branch ([`alternate-branch-for-pr-616`](https://github.com/facebook/regenerator/commits/9eea45b74a1fdcfacab2a4d018e11200e974f623)) will makes some kind of difference…