### PR TITLE
Fix: `yield` / `await` in sparse array

### DIFF
--- a/packages/transform/src/emit.js
+++ b/packages/transform/src/emit.js
@@ -1100,7 +1100,9 @@ Ep.explodeExpression = function(path, ignoreResult) {
   case "ArrayExpression":
     return finish(t.arrayExpression(
       path.get("elements").map(function(elemPath) {
-        if (elemPath.isSpreadElement()) {
+        if (!elemPath.node) {
+          return null;
+        } if (elemPath.isSpreadElement()) {
           return t.spreadElement(
             self.explodeViaTempVar(null, elemPath.get("argument"), hasLeapingChildren)
           );

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -2858,4 +2858,22 @@ describe("expressions containing yield subexpressions", function() {
       done: true,
     });
   });
+
+  it("should work when yield is in a sparse array", function() {
+    function *gen() {
+      return [0, yield "foo", , 3];
+    }
+
+    var g = gen();
+
+    assert.deepEqual(g.next(), {
+      value: "foo",
+      done: false,
+    });
+
+    assert.deepEqual(g.next(1), {
+      value: [0, 1, , 3],
+      done: true,
+    });
+  });
 });


### PR DESCRIPTION
Fix crash when compiling `yield` or `await` in sparse array, and add test `should work when yield is in a sparse array` to verify the fix.
Fixes #627.