### PR TITLE
Fix: GitHub URL in `package.json`

### DIFF
--- a/packages/preset/package.json
+++ b/packages/preset/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/regenerator/tree/master/packages/preset"
+    "url": "https://github.com/facebook/regenerator/tree/main/packages/preset"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,7 +13,7 @@
   "sideEffects": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/regenerator/tree/master/packages/runtime"
+    "url": "https://github.com/facebook/regenerator/tree/main/packages/runtime"
   },
   "license": "MIT"
 }

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/regenerator/tree/master/packages/transform"
+    "url": "https://github.com/facebook/regenerator/tree/main/packages/transform"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Update GitHub URL in `package.json`.

Also, the repository links on [npmjs.com](https://www.npmjs.com/) also need to be updated to `main`:
- [regenerator-preset](https://www.npmjs.com/package/regenerator-preset) (This one goes to 404 now :no_mouth:)
- [regenerator-runtime](https://www.npmjs.com/package/regenerator-runtime)
- [regenerator-transform](https://www.npmjs.com/package/regenerator-transform) (Also 404)