### PR TITLE
Fix: `yield*` should throw if not iterable

### DIFF
--- a/packages/runtime/runtime.js
+++ b/packages/runtime/runtime.js
@@ -487,7 +487,7 @@ var runtime = (function (exports) {
   };
 
   function values(iterable) {
-    if (iterable) {
+    if (iterable || iterable === "") {
       var iteratorMethod = iterable[iteratorSymbol];
       if (iteratorMethod) {
         return iteratorMethod.call(iterable);
@@ -517,8 +517,7 @@ var runtime = (function (exports) {
       }
     }
 
-    // Return an iterator with no values.
-    return { next: doneResult };
+    throw new TypeError(typeof iterable + " is not iterable");
   }
   exports.values = values;
 

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -1504,6 +1504,28 @@ describe("delegated yield", function() {
     check(gen(iterator), [], "1foo");
   });
 
+  it("should work with empty string", function() {
+    function* f() {
+      yield* "";
+    };
+
+    assert.deepEqual(f().next(), { value: undefined, done: true });
+  });
+
+  it("should throw if not iterable", function() {
+    function* f(x) {
+      yield* x;
+    };
+
+    assert.throws(() => f(undefined).next(), TypeError);
+    assert.throws(() => f(null).next(), TypeError);
+    assert.throws(() => f(false).next(), TypeError);
+    assert.throws(() => f(true).next(), TypeError);
+    assert.throws(() => f(0).next(), TypeError);
+    assert.throws(() => f(1).next(), TypeError);
+    assert.throws(() => f({}).next(), TypeError);
+  });
+
   it("should throw if the delegated iterable's iterator doesn't have .next", function() {
     var it = function* () {
       yield* {


### PR DESCRIPTION
`yield*` an non-iterable value should throw `TypeError`, rather than treating it as an iterator with no values.

Fixes #202.
See also: babel/babel#1648, babel/babel#15172