### PR TITLE
Do not use `-1` to mark uninitialized location numeric literals

### DIFF
--- a/packages/transform/src/emit.js
+++ b/packages/transform/src/emit.js
@@ -61,9 +61,9 @@ exports.Emitter = Emitter;
 // so because no code can realistically have about 1.8e+308 locations before
 // hitting memory limit of the machine it's running on. For comparison, the
 // estimated number of atoms in the observable universe is around 1e+80.
-let uninitializedLocation = Number.MAX_VALUE;
+const PENDING_LOCATION = Number.MAX_VALUE;
 Ep.loc = function() {
-  const l = util.getTypes().numericLiteral(uninitializedLocation)
+  const l = util.getTypes().numericLiteral(PENDING_LOCATION)
   this.insertedLocs.add(l);
   return l;
 }
@@ -81,7 +81,7 @@ Ep.getContextId = function() {
 Ep.mark = function(loc) {
   util.getTypes().assertLiteral(loc);
   let index = this.listing.length;
-  if (loc.value === uninitializedLocation) {
+  if (loc.value === PENDING_LOCATION) {
     loc.value = index;
   } else {
     // Locations can be marked redundantly, but their values cannot change
@@ -649,7 +649,7 @@ Ep.explodeStatement = function(path, labelId) {
     );
 
     self.mark(after);
-    if (defaultLoc.value === uninitializedLocation) {
+    if (defaultLoc.value === PENDING_LOCATION) {
       self.mark(defaultLoc);
       assert.strictEqual(after.value, defaultLoc.value);
     }
@@ -890,7 +890,7 @@ Ep.updateContextPrevLoc = function(loc) {
   if (loc) {
     t.assertLiteral(loc);
 
-    if (loc.value === uninitializedLocation) {
+    if (loc.value === PENDING_LOCATION) {
       // If an uninitialized location literal was passed in, set its value
       // to the current this.listing.length.
       loc.value = this.listing.length;

--- a/packages/transform/src/emit.js
+++ b/packages/transform/src/emit.js
@@ -57,8 +57,13 @@ exports.Emitter = Emitter;
 // the amazingly convenient benefit of allowing the exact value of the
 // location to be determined at any time, even after generating code that
 // refers to the location.
+// We use 'Number.MAX_VALUE' to mark uninitialized location. We can safely do
+// so because no code can realistically have about 1.8e+308 locations before
+// hitting memory limit of the machine it's running on. For comparison, the
+// estimated number of atoms in the observable universe is around 1e+80.
+let uninitializedLocation = Number.MAX_VALUE;
 Ep.loc = function() {
-  const l = util.getTypes().numericLiteral(-1)
+  const l = util.getTypes().numericLiteral(uninitializedLocation)
   this.insertedLocs.add(l);
   return l;
 }
@@ -76,7 +81,7 @@ Ep.getContextId = function() {
 Ep.mark = function(loc) {
   util.getTypes().assertLiteral(loc);
   let index = this.listing.length;
-  if (loc.value === -1) {
+  if (loc.value === uninitializedLocation) {
     loc.value = index;
   } else {
     // Locations can be marked redundantly, but their values cannot change
@@ -644,7 +649,7 @@ Ep.explodeStatement = function(path, labelId) {
     );
 
     self.mark(after);
-    if (defaultLoc.value === -1) {
+    if (defaultLoc.value === uninitializedLocation) {
       self.mark(defaultLoc);
       assert.strictEqual(after.value, defaultLoc.value);
     }
@@ -885,7 +890,7 @@ Ep.updateContextPrevLoc = function(loc) {
   if (loc) {
     t.assertLiteral(loc);
 
-    if (loc.value === -1) {
+    if (loc.value === uninitializedLocation) {
       // If an uninitialized location literal was passed in, set its value
       // to the current this.listing.length.
       loc.value = this.listing.length;


### PR DESCRIPTION
In Babel 8 we are going to improve validation in the `t.numericLiteral` builder to only allow valid numeric literals, and it will start throwing for `-1` (since `-1` should be represented as an unary expression).