### PR TITLE
Fix outdated reference link in `runtime.js`

### DIFF
--- a/packages/runtime/runtime.js
+++ b/packages/runtime/runtime.js
@@ -259,8 +259,9 @@ var runtime = (function (exports) {
           throw arg;
         }
 
-        // Be forgiving, per 25.3.3.3.3 of the spec:
-        // https://262.ecma-international.org/6.0/#sec-generatorresume
+        // Be forgiving, per GeneratorResume behavior specified since ES2015:
+        // ES2015 spec, step 3: https://262.ecma-international.org/6.0/#sec-generatorresume
+        // Latest spec, step 2: https://tc39.es/ecma262/#sec-generatorresume
         return doneResult();
       }
 

--- a/packages/runtime/runtime.js
+++ b/packages/runtime/runtime.js
@@ -260,7 +260,7 @@ var runtime = (function (exports) {
         }
 
         // Be forgiving, per 25.3.3.3.3 of the spec:
-        // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generatorresume
+        // https://262.ecma-international.org/6.0/#sec-generatorresume
         return doneResult();
       }
 


### PR DESCRIPTION
related : https://github.com/facebook/regenerator/issues/703

reference link now has 404 error. so i change the link to validated spec document

thank you!!