### PR TITLE
Fix yield * of falsy values

### DIFF
--- a/packages/runtime/runtime.js
+++ b/packages/runtime/runtime.js
@@ -487,7 +487,7 @@ var runtime = (function (exports) {
   };
 
   function values(iterable) {
-    if (iterable || iterable === "") {
+    if (iterable != null) {
       var iteratorMethod = iterable[iteratorSymbol];
       if (iteratorMethod) {
         return iteratorMethod.call(iterable);

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -1537,6 +1537,17 @@ describe("delegated yield", function() {
       it.next();
     }, TypeError);
   });
+
+  it("should work with falsy values", function () {
+    try {
+      Boolean.prototype[Symbol.iterator] = function* () { yield "Hello" };
+      function* gen() { yield* false; };
+
+      check(gen(), ["Hello"]);
+    } finally {
+      delete Boolean.prototype[Symbol.iterator];
+    }
+  });
 });
 
 (fullCompatibility


### PR DESCRIPTION
Test case found while running test262 with Babel: https://github.com/tc39/test262/blob/467a0fe68f633fabde77df94d993c45e840627a0/test/language/expressions/yield/star-in-rltn-expr.js