### PR TITLE
Make the Iterator prototype have its own constructor

### DIFF
--- a/packages/runtime/runtime.js
+++ b/packages/runtime/runtime.js
@@ -82,7 +82,6 @@ var runtime = (function (exports) {
   // minifier not to mangle the names of these two functions.
   function Generator() {}
   function GeneratorFunction() {}
-  function GeneratorFunctionPrototype() {}
 
   // This is a polyfill for %IteratorPrototype% for environments that
   // don't natively support it.
@@ -109,17 +108,16 @@ var runtime = (function (exports) {
     IteratorPrototype = NativeIteratorPrototype;
   }
 
-  var Gp = GeneratorFunctionPrototype.prototype =
-    Generator.prototype = Object.create(IteratorPrototype);
-  GeneratorFunction.prototype = GeneratorFunctionPrototype;
-  defineProperty(Gp, "constructor", { value: GeneratorFunctionPrototype, configurable: true });
+  var Gp = Generator.prototype = Object.create(IteratorPrototype);
+  GeneratorFunction.prototype = Generator;
+  defineProperty(Gp, "constructor", { value: Generator, configurable: true });
   defineProperty(
-    GeneratorFunctionPrototype,
+    Generator,
     "constructor",
     { value: GeneratorFunction, configurable: true }
   );
   GeneratorFunction.displayName = define(
-    GeneratorFunctionPrototype,
+    Generator,
     toStringTagSymbol,
     "GeneratorFunction"
   );
@@ -146,9 +144,9 @@ var runtime = (function (exports) {
 
   exports.mark = function(genFun) {
     if (Object.setPrototypeOf) {
-      Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
+      Object.setPrototypeOf(genFun, Generator);
     } else {
-      genFun.__proto__ = GeneratorFunctionPrototype;
+      genFun.__proto__ = Generator;
       define(genFun, toStringTagSymbol, "GeneratorFunction");
     }
     genFun.prototype = Object.create(Gp);

--- a/packages/runtime/runtime.js
+++ b/packages/runtime/runtime.js
@@ -86,12 +86,20 @@ var runtime = (function (exports) {
 
   // This is a polyfill for %IteratorPrototype% for environments that
   // don't natively support it.
-  var IteratorPrototype = {};
+  var getProto = Object.getPrototypeOf;
+  function Iterator() {
+    if (!IteratorPrototype.isPrototypeOf(this)) {
+      throw new TypeError("Iterator constructor called on non-iterator object");
+    }
+    if (getProto && getProto(this) === IteratorPrototype) {
+      throw new TypeError("Cannot instantiate abstract Iterator class");
+    }
+  }
+  var IteratorPrototype = Iterator.prototype;
   define(IteratorPrototype, iteratorSymbol, function () {
     return this;
   });
 
-  var getProto = Object.getPrototypeOf;
   var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
   if (NativeIteratorPrototype &&
       NativeIteratorPrototype !== Op &&

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -2642,6 +2642,7 @@ describe("generator function prototype", function() {
     assert.notStrictEqual(IteratorPrototype, Object);
     assert.throws(() => Iterator.call({}));
     assert.throws(() => new Iterator());
+    assert.strictEqual(f() instanceof f, true);
 
     if (typeof process === "undefined" ||
         process.version.slice(1, 3) === "0.") {

--- a/test/tests.es6.js
+++ b/test/tests.es6.js
@@ -2625,6 +2625,9 @@ describe("generator function prototype", function() {
 
   it("should follow the expected object model", function() {
     var GeneratorFunctionPrototype = getProto(f);
+    var GeneratorPrototype = GeneratorFunctionPrototype.prototype;
+    var IteratorPrototype = getProto(GeneratorPrototype);
+    var Iterator = IteratorPrototype.constructor;
     var GeneratorFunction = GeneratorFunctionPrototype.constructor;
 
     assert.strictEqual(GeneratorFunction.name, 'GeneratorFunction');
@@ -2636,6 +2639,9 @@ describe("generator function prototype", function() {
                        getProto(f.prototype));
     assert.strictEqual(getProto(GeneratorFunctionPrototype),
                        Function.prototype);
+    assert.notStrictEqual(IteratorPrototype, Object);
+    assert.throws(() => Iterator.call({}));
+    assert.throws(() => new Iterator());
 
     if (typeof process === "undefined" ||
         process.version.slice(1, 3) === "0.") {


### PR DESCRIPTION
This change makes the generator prototype chain fully conformant with ~the spec~ the Iterator Helpers stage 3 proposal, and enables the following code to work when transpiled to older runtimes:

```
const Iterator = Object.getPrototypeOf(Object.getPrototypeOf(Object.getPrototypeOf((function* (){})()))).constructor;

// Add an iterator helper
Iterator.prototype.forEach = function() { /* ... */ }

// Make a custom Iterator class
class RepeatIterator extends Iterator { next() { return { value: 42 } } }

// The iterator helper is available here!
new RepeatIterator().forEach();
```

Of course, the above already works, but since `Iterator.prototype` currently returns the global `Object` prototype, installing `forEach` installs on all objects, which is not the intent, and `RepeatIterator` is not able to function as an `Iterable`, because it does not have the `[Symbol.iterator]` method. So, notably, with this PR, this will work as well:

```
for (const n of new RepeatIterator()) {
  console.log(n);
  break;
}
// prints 42
```

Also, note the above already works if regenerator is used in a standard configuration with preset-env in babel **and** core-js 3 is `require`d (which polyfills the Iterator constructor, and regenerator picks that up as the "native" Iterator prototype), however, regenerator is already almost fully compliant with the prototype chain spec for generators, and I figured it is good for completeness to add this here, as maybe there are cases where regenerator is not used in that combination with the latest core-js that supplies a proper Iterator constructor implementation.

Unit tests have been added.

## Addendum

![4A282A55-0B66-42A1-A217-65EF493BE58C](https://github.com/user-attachments/assets/b1acf6d1-58ae-45b6-9df6-32b7a0f56d0d)

I also went ahead and merged `GeneratorFunctionPrototype` into `Generator`, because the two were duplicates -- `Generator` **is** the prototype of `GeneratorFunction`! `GeneratorFunctionPrototype` was actually the one that was fully setup and `Generator` was not referenced anywhere in the prototype+constructor chain, except it had its own `prototype` property set , which allowed it to be used in an `instanceof` test. That test looks at `Generator.prototype` only, and because both `Generator.prototype` and `GeneratorFunctionPrototype.prototype` were set to the same `GeneratorPrototype` object, both `Generator` and `GeneratorFunctionPrototype` are interchangeable in this position!

In the graphic you can see GFP (`GeneratorFunctionPrototype` in the code) as the object properly setup in the prototype chain and `Generator` is crossed out. You can think of the change as a two-step - 1) remove `Generator`, 2) rename `GeneratorFunctionPrototype` to `Generator`.
